### PR TITLE
Do not start container in workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -49,19 +49,6 @@ jobs:
       - name: Build and Tag
         run: |
           docker build . -f Dockerfile --tag 'ghcr.io/b3partners/tailormap-viewer:${{ env.VERSION_TAG }}' --build-arg BASE_HREF=${{ env.BASE_HREF }} --build-arg NGINX_CONF=${{ env.NGINX_CONF }}
-      - name: Start container
-        run: |
-          docker run --rm --name tailormap-viewer -h tailormap-viewer -d -p '8080:80' 'ghcr.io/b3partners/tailormap-viewer:${{ env.VERSION_TAG }}'
-
-      - name: Test container
-        run: |
-          docker logs tailormap-viewer
-          echo "Container running? "
-          docker inspect -f='{{json .State.Running}}' tailormap-viewer
-          echo "Container health: "
-          docker inspect -f='{{json .State.Health}}' tailormap-viewer
-          curl -Is http://localhost:8080/ | head -n 1
-
       - name: Log in to GitHub container registry
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
       - name: Push image to registry


### PR DESCRIPTION
This fails because nginx fails to start when not running a full stack with the api and db containers to proxy to.
