### PR TITLE
HTM-1205: Prevent creating Solr indexes for WFS feature types

### DIFF
--- a/projects/admin-core/src/lib/catalog/feature-type-selector/feature-type-selector.component.ts
+++ b/projects/admin-core/src/lib/catalog/feature-type-selector/feature-type-selector.component.ts
@@ -60,15 +60,15 @@ export class FeatureTypeSelectorComponent implements OnInit, OnDestroy {
     }
   }
 
-  @Input({transform: (inputValues: string[] | null | undefined) => {
+  @Input({ transform: (inputValues: string[] | null | undefined) => {
     if (inputValues instanceof Array){
       return inputValues.map(
-        excludedFeatureSourceProtocol => FeatureSourceProtocolEnum[excludedFeatureSourceProtocol as keyof typeof FeatureSourceProtocolEnum]
+        excludedFeatureSourceProtocol => FeatureSourceProtocolEnum[excludedFeatureSourceProtocol as keyof typeof FeatureSourceProtocolEnum],
       );
     } else {
       return inputValues;
     }
-  }})
+  } })
   public excludedFeatureSourceProtocols: FeatureSourceProtocolEnum[] | null | undefined;
 
   @Output()

--- a/projects/admin-core/src/lib/catalog/feature-type-selector/feature-type-selector.component.ts
+++ b/projects/admin-core/src/lib/catalog/feature-type-selector/feature-type-selector.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit, ChangeDetectionStrategy, Input, EventEmitter, Output
 import { Store } from '@ngrx/store';
 import { selectFeatureSources, selectFeatureTypesForSource } from '../state/catalog.selectors';
 import { Observable, of, Subject, takeUntil, tap, withLatestFrom } from 'rxjs';
+import { map } from 'rxjs/operators';
 import { ExtendedFeatureSourceModel } from '../models/extended-feature-source.model';
 import { TypesHelper } from '@tailormap-viewer/shared';
 import { FormControl, FormGroup } from '@angular/forms';
@@ -58,6 +59,9 @@ export class FeatureTypeSelectorComponent implements OnInit, OnDestroy {
     }
   }
 
+  @Input()
+  public excludedFeatureSourceProtocols: Array<string> | null | undefined;
+
   @Output()
   public featureTypeSelected = new EventEmitter<{ featureSourceId?: number; featureTypeName?: string; featureTypeId?: string }>();
 
@@ -71,7 +75,12 @@ export class FeatureTypeSelectorComponent implements OnInit, OnDestroy {
   ) { }
 
   public ngOnInit(): void {
-    this.featureSources$ = this.store$.select(selectFeatureSources);
+    this.featureSources$ = this.store$.select(selectFeatureSources)
+      .pipe(
+        map(sources => sources.filter(
+          source => !this.excludedFeatureSourceProtocols?.some(excludedType => excludedType === source.protocol)
+        ))
+      );
     this.featureTypeSelectorForm.valueChanges
       .pipe(
         takeUntil(this.destroyed),

--- a/projects/admin-core/src/lib/catalog/feature-type-selector/feature-type-selector.component.ts
+++ b/projects/admin-core/src/lib/catalog/feature-type-selector/feature-type-selector.component.ts
@@ -60,15 +60,7 @@ export class FeatureTypeSelectorComponent implements OnInit, OnDestroy {
     }
   }
 
-  @Input({ transform: (inputValues: string[] | null | undefined) => {
-    if (inputValues instanceof Array){
-      return inputValues.map(
-        excludedFeatureSourceProtocol => FeatureSourceProtocolEnum[excludedFeatureSourceProtocol as keyof typeof FeatureSourceProtocolEnum],
-      );
-    } else {
-      return inputValues;
-    }
-  } })
+  @Input()
   public excludedFeatureSourceProtocols: FeatureSourceProtocolEnum[] | null | undefined;
 
   @Output()

--- a/projects/admin-core/src/lib/catalog/feature-type-selector/feature-type-selector.component.ts
+++ b/projects/admin-core/src/lib/catalog/feature-type-selector/feature-type-selector.component.ts
@@ -8,6 +8,7 @@ import { TypesHelper } from '@tailormap-viewer/shared';
 import { FormControl, FormGroup } from '@angular/forms';
 import { ExtendedFeatureTypeModel } from '../models/extended-feature-type.model';
 import { GeoServiceHelper } from '../helpers/geo-service.helper';
+import { FeatureSourceProtocolEnum } from '@tailormap-admin/admin-api';
 
 @Component({
   selector: 'tm-admin-feature-type-selector',
@@ -59,8 +60,16 @@ export class FeatureTypeSelectorComponent implements OnInit, OnDestroy {
     }
   }
 
-  @Input()
-  public excludedFeatureSourceProtocols: Array<string> | null | undefined;
+  @Input({transform: (inputValues: string[] | null | undefined) => {
+    if (inputValues instanceof Array){
+      return inputValues.map(
+        excludedFeatureSourceProtocol => FeatureSourceProtocolEnum[excludedFeatureSourceProtocol as keyof typeof FeatureSourceProtocolEnum]
+      );
+    } else {
+      return inputValues;
+    }
+  }})
+  public excludedFeatureSourceProtocols: FeatureSourceProtocolEnum[] | null | undefined;
 
   @Output()
   public featureTypeSelected = new EventEmitter<{ featureSourceId?: number; featureTypeName?: string; featureTypeId?: string }>();

--- a/projects/admin-core/src/lib/catalog/feature-type-selector/feature-type-selector.component.ts
+++ b/projects/admin-core/src/lib/catalog/feature-type-selector/feature-type-selector.component.ts
@@ -78,8 +78,8 @@ export class FeatureTypeSelectorComponent implements OnInit, OnDestroy {
     this.featureSources$ = this.store$.select(selectFeatureSources)
       .pipe(
         map(sources => sources.filter(
-          source => !this.excludedFeatureSourceProtocols?.some(excludedType => excludedType === source.protocol)
-        ))
+          source => !this.excludedFeatureSourceProtocols?.some(excludedType => excludedType === source.protocol),
+        )),
       );
     this.featureTypeSelectorForm.valueChanges
       .pipe(

--- a/projects/admin-core/src/lib/search-index/search-index-form/search-index-form.component.html
+++ b/projects/admin-core/src/lib/search-index/search-index-form/search-index-form.component.html
@@ -14,7 +14,7 @@
   </mat-form-field>
   <div class="form-control">
     <strong i18n="@@admin-core.common.feature-source">Feature source and type</strong>
-    <tm-admin-feature-type-selector [excludedFeatureSourceProtocols]="['WFS']"
+    <tm-admin-feature-type-selector [excludedFeatureSourceProtocols]="nonSearchableFeatureSourceProtocols"
                                     [featureSourceId]="searchIndexForm.get('featureSourceId')?.value"
                                     [featureTypeName]="searchIndexForm.get('featureTypeName')?.value"
                                     [disabled]="!!searchIndex"

--- a/projects/admin-core/src/lib/search-index/search-index-form/search-index-form.component.html
+++ b/projects/admin-core/src/lib/search-index/search-index-form/search-index-form.component.html
@@ -14,7 +14,8 @@
   </mat-form-field>
   <div class="form-control">
     <strong i18n="@@admin-core.common.feature-source">Feature source and type</strong>
-    <tm-admin-feature-type-selector [featureSourceId]="searchIndexForm.get('featureSourceId')?.value"
+    <tm-admin-feature-type-selector [excludedFeatureSourceProtocols]="['WFS']"
+                                    [featureSourceId]="searchIndexForm.get('featureSourceId')?.value"
                                     [featureTypeName]="searchIndexForm.get('featureTypeName')?.value"
                                     [disabled]="!!searchIndex"
                                     (featureTypeSelected)="updateFeatureTypeSelection($event)"></tm-admin-feature-type-selector>

--- a/projects/admin-core/src/lib/search-index/search-index-form/search-index-form.component.ts
+++ b/projects/admin-core/src/lib/search-index/search-index-form/search-index-form.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit, ChangeDetectionStrategy, Input, Output, EventEmitter, DestroyRef } from '@angular/core';
 import { FormControl, FormGroup, Validators } from '@angular/forms';
-import { SearchIndexModel } from '@tailormap-admin/admin-api';
+import { FeatureSourceProtocolEnum, SearchIndexModel } from '@tailormap-admin/admin-api';
 import { debounceTime, filter, map, distinctUntilChanged, concatMap, forkJoin, of, take } from 'rxjs';
 import { FormHelper } from '../../helpers/form.helper';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
@@ -18,6 +18,8 @@ import { FeatureSourceService } from '../../catalog/services/feature-source.serv
 export class SearchIndexFormComponent implements OnInit {
 
   private _searchIndex: SearchIndexModel | null = null;
+
+  public nonSearchableFeatureSourceProtocols: FeatureSourceProtocolEnum[] = [FeatureSourceProtocolEnum.WFS];
 
   @Input()
   public set searchIndex(form: SearchIndexModel | null) {


### PR DESCRIPTION
[![HTM-1205](https://badgen.net/badge/JIRA/HTM-1205/pink?icon=jira)](https://b3partners.atlassian.net/browse/HTM-1205) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=Tailormap&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

HTM-1205 F: Solr indexing supports WFS, this should be disabled (admin)
* Added input option in FeatureTypeSelectorComponent to allow passing in feature source protocols that should be excluded.
* Used input option in search-index-form.component.html to exclude WFS

[HTM-1205]: https://b3partners.atlassian.net/browse/HTM-1205?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ