### PR TITLE
HTM-1230: Fix error exporting layer when WFS does not return a (valid) Content-Disposition header

### DIFF
--- a/projects/shared/src/lib/helpers/file.helper.ts
+++ b/projects/shared/src/lib/helpers/file.helper.ts
@@ -15,7 +15,14 @@ export class FileHelper {
   }
 
   public static extractFileNameFromContentDispositionHeader(contentDispositionHeader: string, defaultName = 'file') {
-    return parse(contentDispositionHeader).parameters['filename'] as string || defaultName;
+    if(contentDispositionHeader === null) {
+      return defaultName;
+    }
+    try {
+      return parse(contentDispositionHeader).parameters['filename'] as string || defaultName;
+    } catch(_ignored) {
+      return defaultName;
+    }
   }
 
   private static getData(data: object | Blob) {


### PR DESCRIPTION
[![HTM-1230](https://badgen.net/badge/JIRA/HTM-1230/pink?icon=jira)](https://b3partners.atlassian.net/browse/HTM-1230) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=Tailormap&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->



[HTM-1230]: https://b3partners.atlassian.net/browse/HTM-1230?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ