### PR TITLE
HTM-816: Escape HTML in layer attributions

### DIFF
--- a/projects/core/src/lib/map/services/application-map.service.ts
+++ b/projects/core/src/lib/map/services/application-map.service.ts
@@ -6,7 +6,7 @@ import {
 import { combineLatest, concatMap, distinctUntilChanged, filter, forkJoin, map, Observable, of, Subject, take, takeUntil, tap } from 'rxjs';
 import { ServiceModel, ServiceProtocol } from '@tailormap-viewer/api';
 import { HttpClient, HttpParams } from '@angular/common/http';
-import { ArrayHelper } from '@tailormap-viewer/shared';
+import { ArrayHelper, HtmlifyHelper } from '@tailormap-viewer/shared';
 import { selectMapOptions, selectOrderedVisibleBackgroundLayers, selectOrderedVisibleLayersWithServices } from '../state/map.selectors';
 import { ExtendedAppLayerModel } from '../models';
 import { selectCQLFilters } from '../../filter/state/filter.selectors';
@@ -113,7 +113,9 @@ export class ApplicationMapService implements OnDestroy {
       // We don't want a 'tainted canvas' for features such as printing. TM requires CORS-enabled or proxied services.
       crossOrigin: 'anonymous',
       opacity: extendedAppLayer.opacity,
-      attribution: extendedAppLayer.attribution,
+      attribution: typeof extendedAppLayer.attribution === 'string'
+        ? HtmlifyHelper.htmlifyContents(extendedAppLayer.attribution)
+        : extendedAppLayer.attribution,
       hiDpiDisabled: extendedAppLayer.hiDpiDisabled,
     };
     if (service.protocol === ServiceProtocol.WMTS) {

--- a/projects/shared/src/lib/helpers/htmlify.helper.spec.ts
+++ b/projects/shared/src/lib/helpers/htmlify.helper.spec.ts
@@ -2,6 +2,14 @@ import { HtmlifyHelper } from './htmlify.helper';
 
 describe('HtmlifyHelper', () => {
 
+  it('prevents XSS/HTML injection', async () => {
+    expect(HtmlifyHelper.htmlifyContents('<script>alert("test");</script>')).toEqual('&lt;script&gt;alert(&quot;test&quot;);&lt;/script&gt;');
+    expect(HtmlifyHelper.htmlifyContents('https://test.nl"onClick="alert(\'test\')'))
+      .toEqual('<a href="https://test.nl&quot;onClick=&quot;alert(&#x27;test&#x27;)" target="_blank">https://test.nl&quot;onClick=&quot;alert(&#x27;test&#x27;)</a>');
+    expect(HtmlifyHelper.htmlifyContents('https://javascript:alert(\'test\')'))
+      .toEqual('<a href="https://alert(&#x27;test&#x27;)" target="_blank">https://alert(&#x27;test&#x27;)</a>');
+  });
+
   it('renders back normal text', async () => {
     expect(HtmlifyHelper.htmlifyContents('Some text')).toEqual('Some text');
   });

--- a/projects/shared/src/lib/helpers/htmlify.helper.spec.ts
+++ b/projects/shared/src/lib/helpers/htmlify.helper.spec.ts
@@ -1,0 +1,53 @@
+import { HtmlifyHelper } from './htmlify.helper';
+
+describe('HtmlifyHelper', () => {
+
+  it('renders back normal text', async () => {
+    expect(HtmlifyHelper.htmlifyContents('Some text')).toEqual('Some text');
+  });
+
+  it('transforms urls into hyperlinks', async () => {
+    expect(HtmlifyHelper.htmlifyContents('Some text with some https://www.test.nl in it'))
+      .toEqual('Some text with some <a href="https://www.test.nl" target="_blank">https://www.test.nl</a> in it');
+  });
+
+  it('transforms images into image tags', async () => {
+    const content = [
+      'Some text with some https://www.test.nl/image.jpg in it',
+      'Some text with some https://www.test.nl/image.jpeg in it',
+      'Some text with some https://www.test.nl/image.png in it',
+      'Some text with some https://www.test.nl/image.svg in it',
+      'Some text with some https://www.test.nl/image.webp in it',
+      'Some text with some https://www.test.nl/image.gif in it',
+      'Some text with a vendor specific image inside https://www.test.nl/getimage.ashx?id=testtest in it',
+      'Some text with a plain link in it https://www.test.nl',
+    ].join(' ');
+    const expected = [
+      'Some text with some <a href="https://www.test.nl/image.jpg" target="_blank"><img src="https://www.test.nl/image.jpg" alt="https://www.test.nl/image.jpg" /></a> in it',
+      'Some text with some <a href="https://www.test.nl/image.jpeg" target="_blank"><img src="https://www.test.nl/image.jpeg" alt="https://www.test.nl/image.jpeg" /></a> in it',
+      'Some text with some <a href="https://www.test.nl/image.png" target="_blank"><img src="https://www.test.nl/image.png" alt="https://www.test.nl/image.png" /></a> in it',
+      'Some text with some <a href="https://www.test.nl/image.svg" target="_blank"><img src="https://www.test.nl/image.svg" alt="https://www.test.nl/image.svg" /></a> in it',
+      'Some text with some <a href="https://www.test.nl/image.webp" target="_blank"><img src="https://www.test.nl/image.webp" alt="https://www.test.nl/image.webp" /></a> in it',
+      'Some text with some <a href="https://www.test.nl/image.gif" target="_blank"><img src="https://www.test.nl/image.gif" alt="https://www.test.nl/image.gif" /></a> in it',
+      // eslint-disable-next-line max-len
+      'Some text with a vendor specific image inside <a href="https://www.test.nl/getimage.ashx?id=testtest" target="_blank"><img src="https://www.test.nl/getimage.ashx?id=testtest" alt="https://www.test.nl/getimage.ashx?id=testtest" /></a> in it',
+      'Some text with a plain link in it <a href="https://www.test.nl" target="_blank">https://www.test.nl</a>',
+    ].join(' ');
+    expect(HtmlifyHelper.htmlifyContents(content)).toEqual(expected);
+  });
+
+  it('transforms MD-links into hyperlinks', async () => {
+    expect(HtmlifyHelper.htmlifyContents('Some text with some [link](https://www.test.nl) in it'))
+      .toEqual('Some text with some <a href="https://www.test.nl" target="_blank">link</a> in it');
+  });
+
+  it('transforms multiple links with whitespace', async () => {
+    expect(HtmlifyHelper.htmlifyContents('Deze laag toont gegevens uit http://www.postgis.net/\r\n\r\nhttps://postgis.net/logos/postgis-logo.png'))
+      // eslint-disable-next-line max-len
+      .toEqual('Deze laag toont gegevens uit <a href="http://www.postgis.net/" target="_blank">http://www.postgis.net/</a><br />\r\n<br />\r\n<a href="https://postgis.net/logos/postgis-logo.png" target="_blank"><img src="https://postgis.net/logos/postgis-logo.png" alt="https://postgis.net/logos/postgis-logo.png" /></a>');
+    expect(HtmlifyHelper.htmlifyContents('Deze laag toont gegevens uit http://www.postgis.net/ https://postgis.net/logos/postgis-logo.png'))
+      // eslint-disable-next-line max-len
+      .toEqual('Deze laag toont gegevens uit <a href="http://www.postgis.net/" target="_blank">http://www.postgis.net/</a> <a href="https://postgis.net/logos/postgis-logo.png" target="_blank"><img src="https://postgis.net/logos/postgis-logo.png" alt="https://postgis.net/logos/postgis-logo.png" /></a>');
+  });
+
+});

--- a/projects/shared/src/lib/helpers/htmlify.helper.ts
+++ b/projects/shared/src/lib/helpers/htmlify.helper.ts
@@ -42,7 +42,10 @@ export class HtmlifyHelper {
     return text
       .replace(/&/g, '&amp;')
       .replace(/</g, '&lt;')
-      .replace(/>/g, '&gt;');
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#x27;')
+      .replace(/(javascript|data):/g, '');
   }
 
 }

--- a/projects/shared/src/lib/helpers/htmlify.helper.ts
+++ b/projects/shared/src/lib/helpers/htmlify.helper.ts
@@ -1,0 +1,48 @@
+/**
+ * This helper is meant to convert some text with links and images to HTML.
+ * Support for simple Markdown links, converts http-uri or images to HTML links/images.
+ * For full Markdown support use the Markdown helper
+ */
+export class HtmlifyHelper {
+
+  // Matches everything that starts with http until the first space
+  private static readonly URL_PART = 'https?:\\/\\/[^\\s\\r\\n]*';
+  // Matches a Markdown URL: [LABEL](URL)
+  private static readonly MD_PART = '\\[[\\w\\s\\d]+]\\(https?:\\/\\/[^) ]*\\)';
+
+  private static readonly URL_REGEXP = new RegExp(`${HtmlifyHelper.MD_PART}|${HtmlifyHelper.URL_PART}`, 'ig');
+  private static readonly IMG_REGEXP = /\.(jpg|jpeg|png|webp|svg|gif)/i;
+  private static readonly VENDOR_SPECIFIC_IMAGE_REGEXP = /getimage\.ashx/i;
+  private static readonly NEWLINE_REGEXP = /([^>\r\n]?)(\r\n|\n\r|\r|\n)/g;
+
+  public static htmlifyContents(text: string) {
+    const sanitizedHTML = HtmlifyHelper.escapeHTML(text || '');
+    if (!sanitizedHTML) {
+      return sanitizedHTML;
+    }
+    const replaceUrls = sanitizedHTML.replace(HtmlifyHelper.URL_REGEXP, HtmlifyHelper.linkReplacer);
+    const replacedBreaks = replaceUrls.replace(HtmlifyHelper.NEWLINE_REGEXP, '$1<br />$2');
+    return replacedBreaks;
+  }
+
+  private static linkReplacer(match: string): string {
+    if (match[0] === '[') { // safe to do since this is already matched using Regex, only MD URL will start with [
+      const url = match.substring(match.indexOf('(') + 1, match.length - 1);
+      const name = match.substring(1, match.indexOf(']'));
+      return `<a href="${url}" target="_blank">${name}</a>`;
+    }
+    if (HtmlifyHelper.IMG_REGEXP.test(match)
+      || HtmlifyHelper.VENDOR_SPECIFIC_IMAGE_REGEXP.test(match)) {
+      return `<a href="${match}" target="_blank"><img src="${match}" alt="${match}" /></a>`;
+    }
+    return `<a href="${match}" target="_blank">${match}</a>`;
+  }
+
+  private static escapeHTML(text: string) {
+    return text
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;');
+  }
+
+}

--- a/projects/shared/src/lib/helpers/index.ts
+++ b/projects/shared/src/lib/helpers/index.ts
@@ -18,3 +18,4 @@ export * from './debounce.helper';
 export * from './clipboard.helper';
 export * from './filter.helper';
 export * from './markdown.helper';
+export * from './htmlify.helper';

--- a/projects/shared/src/lib/pipes/htmlify.constants.ts
+++ b/projects/shared/src/lib/pipes/htmlify.constants.ts
@@ -1,6 +1,0 @@
-export class HtmlifyConstants {
-  // Matches everything that starts with http until the first space
-  public static readonly URL_PART = 'https?:\\/\\/[^\\s\\r\\n]*';
-  // Matches a Markdown URL: [LABEL](URL)
-  public static readonly MD_PART = '\\[[\\w\\s\\d]+]\\(https?:\\/\\/[^) ]*\\)';
-}

--- a/projects/shared/src/lib/pipes/htmlify.pipe.ts
+++ b/projects/shared/src/lib/pipes/htmlify.pipe.ts
@@ -1,6 +1,6 @@
 import { Pipe, PipeTransform } from '@angular/core';
 import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
-import { HtmlifyConstants } from './htmlify.constants';
+import { HtmlifyHelper } from '../helpers/htmlify.helper';
 
 @Pipe({
   name: 'htmlify',
@@ -9,42 +9,11 @@ export class HtmlifyPipe implements PipeTransform {
 
   public constructor(private sanitizer: DomSanitizer) {}
 
-  private static readonly URL_REGEXP = new RegExp(`${HtmlifyConstants.MD_PART}|${HtmlifyConstants.URL_PART}`, 'ig');
-  private static readonly IMG_REGEXP = /\.(jpg|jpeg|png|webp|svg|gif)/i;
-  private static readonly VENDOR_SPECIFIC_IMAGE_REGEXP = /getimage\.ashx/i;
-  private static readonly NEWLINE_REGEXP = /([^>\r\n]?)(\r\n|\n\r|\r|\n)/g;
-
-  private static linkReplacer(match: string): string {
-    if (match[0] === '[') { // safe to do since this is already matched using Regex, only MD URL will start with [
-      const url = match.substring(match.indexOf('(') + 1, match.length - 1);
-      const name = match.substring(1, match.indexOf(']'));
-      return `<a href="${url}" target="_blank">${name}</a>`;
-    }
-    if (HtmlifyPipe.IMG_REGEXP.test(match)
-      || HtmlifyPipe.VENDOR_SPECIFIC_IMAGE_REGEXP.test(match)) {
-      return `<a href="${match}" target="_blank"><img src="${match}" alt="${match}" /></a>`;
-    }
-    return `<a href="${match}" target="_blank">${match}</a>`;
-  }
-
   public transform(value: string | null): SafeHtml | null {
     if (typeof value === 'string') {
-      const sanitizedHTML = HtmlifyPipe.escapeText(value);
-      if (!sanitizedHTML) {
-        return sanitizedHTML;
-      }
-      const replaceUrls = sanitizedHTML.replace(HtmlifyPipe.URL_REGEXP, HtmlifyPipe.linkReplacer);
-      const replacedBreaks = replaceUrls.replace(HtmlifyPipe.NEWLINE_REGEXP, '$1<br />$2');
-      return this.sanitizer.bypassSecurityTrustHtml(replacedBreaks);
+      return this.sanitizer.bypassSecurityTrustHtml(HtmlifyHelper.htmlifyContents(value));
     }
     return value;
-  }
-
-  private static escapeText(text: string) {
-    return text
-      .replace(/&/g, '&amp;')
-      .replace(/</g, '&lt;')
-      .replace(/>/g, '&gt;');
   }
 
 }


### PR DESCRIPTION
[![HTM-816](https://badgen.net/badge/JIRA/HTM-816/pink?icon=jira)](https://b3partners.atlassian.net/browse/HTM-816) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=Tailormap&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->



[HTM-816]: https://b3partners.atlassian.net/browse/HTM-816?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

This is a somewhat breaking change. If previously HTML was used in attributions this will now render as plain text so attributions might need be converted to non-HTML with (optional) Markdown style links