### PR TITLE
HTM-1261: Maximum width for feature-info layer-list

### DIFF
--- a/projects/core/src/lib/components/feature-info/feature-info-dialog/feature-info-dialog.component.css
+++ b/projects/core/src/lib/components/feature-info/feature-info-dialog/feature-info-dialog.component.css
@@ -16,6 +16,7 @@
   border-right: 1px solid var(--border-color);
   display: flex;
   flex-direction: column;
+  max-width: 50%;
 }
 
 .toggle {

--- a/projects/core/src/lib/components/feature-info/feature-info-layer-item/feature-info-layer-item.component.css
+++ b/projects/core/src/lib/components/feature-info/feature-info-layer-item/feature-info-layer-item.component.css
@@ -8,10 +8,9 @@
 
 .layer-item .title {
   flex: 1;
-  text-overflow: ellipsis;
   overflow: hidden;
-  white-space: nowrap;
   padding-left: 6px;
+  overflow-wrap: break-word;
 }
 
 .layer-item mat-icon {


### PR DESCRIPTION
[![HTM-1261](https://badgen.net/badge/JIRA/HTM-1261/pink?icon=jira)](https://b3partners.atlassian.net/browse/HTM-1261) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=Tailormap&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

* Added maximum width for feature-info layer-list-wrapper 
* Make layer title in feature-info-layer-item wrap so the entire title is displayed

[HTM-1261]: https://b3partners.atlassian.net/browse/HTM-1261?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ