### PR TITLE
HTM-1264: Make long layer titles visible in TOC

### DIFF
--- a/projects/core/src/lib/components/toc/toc-node-layer/toc-node-layer.component.css
+++ b/projects/core/src/lib/components/toc/toc-node-layer/toc-node-layer.component.css
@@ -15,6 +15,10 @@
   align-items: center;
 }
 
+.tree-node__label-content {
+  white-space: wrap;
+}
+
 .tree-node__label.modified {
   font-weight: bold;
 }

--- a/projects/core/src/lib/components/toc/toc-node-layer/toc-node-layer.component.css
+++ b/projects/core/src/lib/components/toc/toc-node-layer/toc-node-layer.component.css
@@ -9,6 +9,10 @@
   line-height: 18px;
 }
 
+.tree-node {
+  padding: 5px 0;
+}
+
 .tree-node__label {
   padding-right: 16px;
   display: flex;
@@ -17,6 +21,7 @@
 
 .tree-node__label-content {
   white-space: wrap;
+  overflow-wrap: break-word;
 }
 
 .tree-node__label.modified {
@@ -37,35 +42,6 @@
   position: relative;
   display: inline-block;
   vertical-align: middle;
-}
-
-.tree-node__actions {
-  position: sticky;
-  right: 0;
-  display: flex;
-  padding-left: 5px;
-  align-items: center;
-  justify-content: center;
-  height: var(--tree-node-size);
-  background-image: linear-gradient(to right, rgba(255, 255, 255, 0) 0%, rgba(255, 255, 255, 1) 20%, rgba(255, 255, 255, 1) 100%);
-}
-
-.tree-node__actions::after {
-  /* mask to cover text behind the icon */
-  content: " ";
-  position: absolute;
-  right: calc(-1 * var(--toc-side-padding));
-  width: var(--toc-side-padding);
-  height: 100%;
-  background-color: #fff;
-}
-
-.tree-node__actions mat-icon {
-  --mdc-icon-button-icon-size: 18px;
-  width: var(--mdc-icon-button-icon-size);
-  height: var(--mdc-icon-button-icon-size);
-  overflow: visible;
-  vertical-align: top;
 }
 
 .out-of-scale {

--- a/projects/core/src/lib/components/toc/toc-node-layer/toc-node-layer.component.html
+++ b/projects/core/src/lib/components/toc/toc-node-layer/toc-node-layer.component.html
@@ -5,6 +5,5 @@
     <div class="tree-node__label">
       <span class="tree-node__label-content">{{node.label}}</span>
     </div>
-    <div class="tree-node__actions"></div>
   </div>
 }

--- a/projects/core/src/lib/components/toc/toc/toc.component.css
+++ b/projects/core/src/lib/components/toc/toc/toc.component.css
@@ -9,11 +9,11 @@
 }
 
 .toc-tree ::ng-deep .mat-tree-node {
-  height: fit-content !important;
+  height: fit-content;
 }
 
 .toc-tree ::ng-deep .tree-node-wrapper {
-  height: fit-content !important;
+  height: fit-content;
 }
 
 ::ng-deep .tree-node-wrapper {

--- a/projects/core/src/lib/components/toc/toc/toc.component.css
+++ b/projects/core/src/lib/components/toc/toc/toc.component.css
@@ -8,8 +8,16 @@
   padding-right: var(--toc-side-padding);
 }
 
+.toc-tree ::ng-deep .mat-tree-node {
+  height: fit-content !important;
+}
+
+.toc-tree ::ng-deep .tree-node-wrapper {
+  height: fit-content !important;
+}
+
 ::ng-deep .tree-node-wrapper {
-    cursor: pointer;
+  cursor: pointer;
 }
 
 ::ng-deep .mat-tree {


### PR DESCRIPTION
[![HTM-1264](https://badgen.net/badge/JIRA/HTM-1264/pink?icon=jira)](https://b3partners.atlassian.net/browse/HTM-1264) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=Tailormap&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

* Set height of tree-node in toc-tree to fit-content.
* Made text in .tree-node__label-content wrap.

[HTM-1264]: https://b3partners.atlassian.net/browse/HTM-1264?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ