### PR TITLE
HTM-1264: long layer titles are broken over multiple lines

### DIFF
--- a/projects/core/src/lib/components/toc/toc-node-layer/toc-node-layer.component.css
+++ b/projects/core/src/lib/components/toc/toc-node-layer/toc-node-layer.component.css
@@ -21,7 +21,7 @@
 
 .tree-node__label-content {
   white-space: wrap;
-  overflow-wrap: break-word;
+  overflow-wrap: anywhere;
 }
 
 .tree-node__label.modified {


### PR DESCRIPTION
[![HTM-1264](https://badgen.net/badge/JIRA/HTM-1264/pink?icon=jira)](https://b3partners.atlassian.net/browse/HTM-1264) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=Tailormap&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

long layer titles are broken up between words, but if the word is too long it breaks anywhere.

[HTM-1264]: https://b3partners.atlassian.net/browse/HTM-1264?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ