### PR TITLE
HTM-1334 | HTM-1335: Markdown fixes

### DIFF
--- a/projects/shared/src/lib/helpers/htmlify.helper.ts
+++ b/projects/shared/src/lib/helpers/htmlify.helper.ts
@@ -6,15 +6,15 @@
 export class HtmlifyHelper {
 
   // Matches everything that starts with http until the first space
-  private static readonly URL_PART = 'https?:\\/\\/[^\\s\\r\\n]*';
+  public static readonly URL_PART = 'https?:\\/\\/[^\\s\\r\\n]*';
   // Matches a Markdown URL: [LABEL](URL)
-  private static readonly MD_PART = '\\[(.*?(?:\\\\[()[\\]]|[^\\[\\]()])*?)\\]\\((.*?)\\)';
+  public static readonly MD_PART = '\\[(.*?(?:\\\\[()[\\]]|[^\\[\\]()])*?)\\]\\((.*?)\\)';
 
-  private static readonly URL_REGEXP = new RegExp(`${HtmlifyHelper.MD_PART}|${HtmlifyHelper.URL_PART}`, 'ig');
-  private static readonly MD_URL_REGEXP = new RegExp(HtmlifyHelper.MD_PART, 'i');
-  private static readonly IMG_REGEXP = /\.(jpg|jpeg|png|webp|svg|gif)/i;
-  private static readonly VENDOR_SPECIFIC_IMAGE_REGEXP = /getimage\.ashx/i;
-  private static readonly NEWLINE_REGEXP = /([^>\r\n]?)(\r\n|\n\r|\r|\n)/g;
+  public static readonly URL_REGEXP = new RegExp(`${HtmlifyHelper.MD_PART}|${HtmlifyHelper.URL_PART}`, 'ig');
+  public static readonly MD_URL_REGEXP = new RegExp(HtmlifyHelper.MD_PART, 'i');
+  public static readonly IMG_REGEXP = /\.(jpg|jpeg|png|webp|svg|gif)/i;
+  public static readonly VENDOR_SPECIFIC_IMAGE_REGEXP = /getimage\.ashx/i;
+  public static readonly NEWLINE_REGEXP = /([^>\r\n]?)(\r\n|\n\r|\r|\n)/g;
 
   public static htmlifyContents(text: string) {
     const sanitizedHTML = HtmlifyHelper.escapeHTML(text || '');
@@ -26,13 +26,21 @@ export class HtmlifyHelper {
     return replacedBreaks;
   }
 
+  public static getMarkdownLinkParts(mdLink: string): null | { url: string; label: string } {
+    const mdUrlMatches = HtmlifyHelper.MD_URL_REGEXP.exec(mdLink);
+    if (!mdUrlMatches || mdUrlMatches.length === 0) {
+      return null;
+    }
+    return { url: mdUrlMatches[2], label: mdUrlMatches[1] };
+  }
+
   private static linkReplacer(match: string): string {
     if (match[0] === '[') { // safe to do since this is already matched using Regex, only MD URL will start with [
-      const mdUrlMatches = HtmlifyHelper.MD_URL_REGEXP.exec(match);
-      if (!mdUrlMatches || mdUrlMatches.length === 0) {
+      const linkParts = HtmlifyHelper.getMarkdownLinkParts(match);
+      if (linkParts === null) {
         return HtmlifyHelper.getLink(match);
       }
-      return `<a href="${mdUrlMatches[2]}" target="_blank">${mdUrlMatches[1]}</a>`;
+      return `<a href="${linkParts.url}" target="_blank">${linkParts.label}</a>`;
     }
     return HtmlifyHelper.getLink(match);
   }

--- a/projects/shared/src/lib/helpers/markdown.helper.spec.ts
+++ b/projects/shared/src/lib/helpers/markdown.helper.spec.ts
@@ -19,4 +19,17 @@ describe('MarkdownHelper', () => {
     expect(result).toEqual('Some story about Some value. Value 2 should be replaced. {{ Leave this Other one and this }}');
   });
 
+  test('parses template and fixes white space in urls', () => {
+    const variables = new Map([
+      [ 'var1', 'Some value' ],
+      [ 'var2', 'Value 2' ],
+      [ 'var3', 'Other one' ],
+      [ 'filename', 'my doc.pdf' ],
+    ]);
+    const template = 'Some story about {{var1}}. {{ var2 }} should be replaced. {{ Leave this {{ var3 }} and this }}. [Do add a link though](https://www.test.nl/{{filename}})';
+    const result = MarkdownHelper.templateParser(template, variables);
+    expect(result)
+      .toEqual('Some story about Some value. Value 2 should be replaced. {{ Leave this Other one and this }}. [Do add a link though](https://www.test.nl/my%20doc.pdf)');
+  });
+
 });

--- a/projects/shared/src/lib/helpers/markdown.helper.spec.ts
+++ b/projects/shared/src/lib/helpers/markdown.helper.spec.ts
@@ -4,6 +4,8 @@ describe('MarkdownHelper', () => {
 
   test('escapes markdown', () => {
     expect(MarkdownHelper.markdownEscape('123')).toEqual('123');
+    expect(MarkdownHelper.markdownEscape(123)).toEqual('123');
+    expect(MarkdownHelper.markdownEscape(true)).toEqual('true');
     expect(MarkdownHelper.markdownEscape('* _123_')).toEqual('\\* \\_123\\_');
     expect(MarkdownHelper.markdownEscape('___ abc # test ## test2')).toEqual('\\_\\_\\_ abc \\# test \\#\\# test2');
   });

--- a/projects/shared/src/lib/helpers/markdown.helper.ts
+++ b/projects/shared/src/lib/helpers/markdown.helper.ts
@@ -36,7 +36,7 @@ export class MarkdownHelper {
     return MarkdownHelper.replaceWhitespaceInLinks(replacedTemplate);
   }
 
-  public static markdownEscape(str?: string | null): string {
+  public static markdownEscape(str?: string | number | boolean | null): string {
     // from https://github.com/mattcone/markdown-guide/blob/master/_basic-syntax/escaping-characters.md
     // \ 	backslash
     // ` 	backtick (see also escaping backticks in code)
@@ -52,8 +52,8 @@ export class MarkdownHelper {
     // . 	dot
     // ! 	exclamation mark
     // | 	pipe (see also escaping pipe in tables)
-    if (typeof str !== "string" || str === "") {
-      return "";
+    if (typeof str !== "string") {
+      return `${str}`;
     }
     return str.replace(MarkdownHelper.ESCAPE_REGEX, '\\$&');
   }


### PR DESCRIPTION
[![HTM-1334](https://badgen.net/badge/JIRA/HTM-1334/pink?icon=jira)](https://b3partners.atlassian.net/browse/HTM-1334) [![HTM-1335](https://badgen.net/badge/JIRA/HTM-1335/pink?icon=jira)](https://b3partners.atlassian.net/browse/HTM-1335)[<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=Tailormap&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

HTM-1334: Escape spaces in markdown-link urls
HTM-1335: Fix markdown escaping other values than strings

[HTM-1334]: https://b3partners.atlassian.net/browse/HTM-1334?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HTM-1335]: https://b3partners.atlassian.net/browse/HTM-1335?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ