### PR TITLE
HTM-1368: Update SearchIndexModel and usage for API change

### DIFF
--- a/projects/admin-api/src/lib/models/search-index-summary.model.ts
+++ b/projects/admin-api/src/lib/models/search-index-summary.model.ts
@@ -1,0 +1,7 @@
+export interface SearchIndexSummaryModel {
+  total?: number;
+  skippedCounter?: number;
+  startedAt?: Date | string | null;
+  duration?: number;
+  errorMessage?: string | null;
+}

--- a/projects/admin-api/src/lib/models/search-index.model.ts
+++ b/projects/admin-api/src/lib/models/search-index.model.ts
@@ -1,5 +1,6 @@
 import { SearchIndexStatusEnum } from './search-index-status.enum';
 import { TaskSchedule } from './taskschedule.model';
+import { SearchIndexSummaryModel } from './search-index-summary.model';
 
 export interface SearchIndexModel {
   id: number;
@@ -7,8 +8,8 @@ export interface SearchIndexModel {
   lastIndexed: Date | string | null;
   name: string;
   status: SearchIndexStatusEnum;
-  comment: string;
   searchFieldsUsed: string[];
   searchDisplayFieldsUsed: string[];
   schedule?: TaskSchedule;
+  summary?: SearchIndexSummaryModel;
 }

--- a/projects/admin-core/assets/locale/messages.admin-core.de.xlf
+++ b/projects/admin-core/assets/locale/messages.admin-core.de.xlf
@@ -874,14 +874,6 @@
         <source>Collapse all</source>
         <target>Alle einklappen</target>
       </trans-unit>
-      <trans-unit id="admin-core.common.comment" datatype="html">
-        <source>Comment</source>
-        <target>Kommentar</target>
-      </trans-unit>
-      <trans-unit id="admin-core.common.comment" datatype="html">
-        <source>Comment</source>
-        <target>Kommentar</target>
-      </trans-unit>
       <trans-unit id="admin-core.common.comments" datatype="html">
         <source>Comments</source>
         <target>Kommentare</target>

--- a/projects/admin-core/assets/locale/messages.admin-core.en.xlf
+++ b/projects/admin-core/assets/locale/messages.admin-core.en.xlf
@@ -656,9 +656,6 @@
       <trans-unit id="admin-core.common.collapse-all" datatype="html">
         <source>Collapse all</source>
       </trans-unit>
-      <trans-unit id="admin-core.common.comment" datatype="html">
-        <source>Comment</source>
-      </trans-unit>
       <trans-unit id="admin-core.common.comments" datatype="html">
         <source>Comments</source>
       </trans-unit>

--- a/projects/admin-core/assets/locale/messages.admin-core.nl.xlf
+++ b/projects/admin-core/assets/locale/messages.admin-core.nl.xlf
@@ -873,14 +873,6 @@
         <source>Collapse all</source>
         <target>Alles inklappen</target>
       </trans-unit>
-      <trans-unit id="admin-core.common.comment" datatype="html">
-        <source>Comment</source>
-        <target>Opmerking</target>
-      </trans-unit>
-      <trans-unit id="admin-core.common.comment" datatype="html">
-        <source>Comment</source>
-        <target>Opmerking</target>
-      </trans-unit>
       <trans-unit id="admin-core.common.comments" datatype="html">
         <source>Comments</source>
         <target>Opmerkingen</target>

--- a/projects/admin-core/src/lib/search-index/search-index-create/search-index-create.component.ts
+++ b/projects/admin-core/src/lib/search-index/search-index-create/search-index-create.component.ts
@@ -13,7 +13,7 @@ import { SearchIndexService } from '../services/search-index.service';
 export class SearchIndexCreateComponent {
 
   public saveEnabled = signal(false);
-  private updatedSearch: Pick<SearchIndexModel, 'name' | 'featureTypeId' | 'comment'> | undefined;
+  private updatedSearch: Pick<SearchIndexModel, 'name' | 'featureTypeId'> | undefined;
 
   private savingSubject = new BehaviorSubject(false);
   public saving$ = this.savingSubject.asObservable();
@@ -28,7 +28,7 @@ export class SearchIndexCreateComponent {
     this.saveEnabled.set($event);
   }
 
-  public updateSearchIndex($event: { searchIndex: Pick<SearchIndexModel, 'name' | 'featureTypeId' | 'comment'> }) {
+  public updateSearchIndex($event: { searchIndex: Pick<SearchIndexModel, 'name' | 'featureTypeId'> }) {
     this.updatedSearch = $event.searchIndex;
   }
 
@@ -38,7 +38,6 @@ export class SearchIndexCreateComponent {
     }
     const searchIndexModel: Omit<SearchIndexModel, 'id'> = {
       name: this.updatedSearch.name,
-      comment: this.updatedSearch.comment,
       featureTypeId: this.updatedSearch.featureTypeId,
       searchFieldsUsed: [],
       searchDisplayFieldsUsed: [],

--- a/projects/admin-core/src/lib/search-index/search-index-edit/search-index-edit.component.ts
+++ b/projects/admin-core/src/lib/search-index/search-index-edit/search-index-edit.component.ts
@@ -70,7 +70,7 @@ export class SearchIndexEditComponent implements OnInit {
     this.saveEnabled.set($event);
   }
 
-  public updateSearchIndex(id: number, $event: { searchIndex: Pick<SearchIndexModel, 'name' | 'featureTypeId' | 'comment'> }) {
+  public updateSearchIndex(id: number, $event: { searchIndex: Pick<SearchIndexModel, 'name' | 'featureTypeId'> }) {
     this.store$.dispatch(updateDraftSearchIndex({ id, searchIndex: $event.searchIndex }));
   }
 

--- a/projects/admin-core/src/lib/search-index/search-index-form/search-index-form.component.html
+++ b/projects/admin-core/src/lib/search-index/search-index-form/search-index-form.component.html
@@ -8,10 +8,6 @@
            formControlName="name"
     />
   </mat-form-field>
-  <mat-form-field>
-    <mat-label i18n="@@admin-core.common.comment">Comment</mat-label>
-    <textarea formControlName="comment" matInput></textarea>
-  </mat-form-field>
   <div class="form-control">
     <strong i18n="@@admin-core.common.feature-source">Feature source and type</strong>
     <tm-admin-feature-type-selector [excludedFeatureSourceProtocols]="nonSearchableFeatureSourceProtocols"

--- a/projects/admin-core/src/lib/search-index/search-index-form/search-index-form.component.ts
+++ b/projects/admin-core/src/lib/search-index/search-index-form/search-index-form.component.ts
@@ -31,7 +31,7 @@ export class SearchIndexFormComponent implements OnInit {
   }
 
   @Output()
-  public updateSearchIndex = new EventEmitter<{ searchIndex: Pick<SearchIndexModel, 'name' | 'featureTypeId' | 'comment'> }>();
+  public updateSearchIndex = new EventEmitter<{ searchIndex: Pick<SearchIndexModel, 'name' | 'featureTypeId'> }>();
 
   @Output()
   public validFormChanged = new EventEmitter<boolean>();
@@ -78,10 +78,9 @@ export class SearchIndexFormComponent implements OnInit {
         }),
       )
       .subscribe(([ value, featureType ]) => {
-        const searchIndex: Pick<SearchIndexModel, 'name' | 'featureTypeId' | 'comment'> = {
+        const searchIndex: Pick<SearchIndexModel, 'name' | 'featureTypeId'> = {
           name: value.name || '',
           featureTypeId: featureType ? +featureType.originalId : -1,
-          comment: value.comment || '',
         };
         this.updateSearchIndex.emit({ searchIndex });
       });
@@ -115,7 +114,6 @@ export class SearchIndexFormComponent implements OnInit {
       .subscribe(featureType => {
         this.searchIndexForm.patchValue({
           name: form.name,
-          comment: form.comment,
           featureSourceId: featureType ? +featureType.featureSourceId : undefined,
           featureTypeName: featureType?.name,
         }, { emitEvent: false });

--- a/projects/admin-core/src/lib/search-index/state/search-index.actions.ts
+++ b/projects/admin-core/src/lib/search-index/state/search-index.actions.ts
@@ -43,7 +43,7 @@ export const updateDraftSearchIndex = createAction(
   `${searchIndexActionsPrefix} Update Draft Search Index`,
   props<{
     id: number;
-    searchIndex: Partial<Pick<SearchIndexModel, 'name' | 'comment' | 'featureTypeId' | 'searchFieldsUsed' | 'searchDisplayFieldsUsed' | 'schedule'>>;
+    searchIndex: Partial<Pick<SearchIndexModel, 'name' | 'summary' | 'featureTypeId' | 'searchFieldsUsed' | 'searchDisplayFieldsUsed' | 'schedule'>>;
   }>(),
 );
 


### PR DESCRIPTION
[![HTM-1368](https://badgen.net/badge/JIRA/HTM-1368/pink?icon=jira)](https://b3partners.atlassian.net/browse/HTM-1368) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=Tailormap&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

removes the `comment` field and add the `summary` to the models (using the summary information is for a different PR)

must be merged with https://github.com/Tailormap/tailormap-api/pull/1082

[HTM-1368]: https://b3partners.atlassian.net/browse/HTM-1368?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ