### PR TITLE
HTM-1401 | HTM-1402 | HTM-1404: Update task-progress event to have optional map of task data and use that to show indexing progress

### DIFF
--- a/projects/admin-core/src/lib/shared/services/admin-sse.service.ts
+++ b/projects/admin-core/src/lib/shared/services/admin-sse.service.ts
@@ -25,6 +25,7 @@ export interface SSETaskProgressEvent extends SSEEvent {
     progress?: number;
     total?: number;
     startedAt?: string;
+    taskData?: any;
   };
   eventType: EventType.TASK_PROGRESS;
 }

--- a/projects/admin-core/src/lib/shared/services/admin-sse.service.ts
+++ b/projects/admin-core/src/lib/shared/services/admin-sse.service.ts
@@ -25,6 +25,7 @@ export interface SSETaskProgressEvent extends SSEEvent {
     progress?: number;
     total?: number;
     startedAt?: string;
+    // we don't want to type this, as it will be different depending on the task type
     taskData?: any;
   };
   eventType: EventType.TASK_PROGRESS;


### PR DESCRIPTION
[![HTM-1402](https://badgen.net/badge/JIRA/HTM-1402/pink?icon=jira)](https://b3partners.atlassian.net/browse/HTM-1402)
[![HTM-1402](https://badgen.net/badge/JIRA/HTM-1404/pink?icon=jira)](https://b3partners.atlassian.net/browse/HTM-1404) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=Tailormap&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

- [x] HTM-1402: Update task-progress event to have optional map of task data
- [x] HTM-1404: Update progress event usage in the admin frontend

companion to https://github.com/Tailormap/tailormap-api/pull/1105, part of https://b3partners.atlassian.net/browse/HTM-1401


[HTM-1402]: https://b3partners.atlassian.net/browse/HTM-1402?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ