### PR TITLE
HTM-1371: Can't search for values with spaces in them with Solr

### DIFF
--- a/projects/core/src/lib/components/toolbar/simple-search/simple-search.service.ts
+++ b/projects/core/src/lib/components/toolbar/simple-search/simple-search.service.ts
@@ -55,7 +55,7 @@ export class SimpleSearchService {
     return this.api.search$({
       applicationId,
       layerId: layer.id,
-      query: `*${searchTerm}*`,
+      query: `(*${searchTerm}*)`,
     }).pipe(
       catchError(() => of({ documents: [], maxScore: 0, start: 0, total: 0 })),
       map<SearchResponseModel, SearchResultModel | null>(searchResponse => {


### PR DESCRIPTION
[![HTM-1371](https://badgen.net/badge/JIRA/HTM-1371/pink?icon=jira)](https://b3partners.atlassian.net/browse/HTM-1371) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=Tailormap&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

add parenthesis to preserve whitespace in the `searchTerm`; this should fix the problem, as demonstrated here: https://github.com/Tailormap/tailormap-api/blob/b3c9b38d9a1c1038a659ee43e3d3948c33ff4ecc/src/test/java/org/tailormap/api/controller/SearchControllerIntegrationTest.java#L223-L239

[HTM-1371]: https://b3partners.atlassian.net/browse/HTM-1371?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ