### PR TITLE
HTM-1060: Support i18n in map service requests

### DIFF
--- a/projects/core/src/lib/components/legend/legend/legend.component.spec.ts
+++ b/projects/core/src/lib/components/legend/legend/legend.component.spec.ts
@@ -64,10 +64,12 @@ describe('LegendComponent', () => {
     const url3 = new URL(images[2].getAttribute('src') || '');
     expect(url3.host).toEqual('layer-3-url');
     expect(url3.searchParams.get('SCALE')).toEqual('1000');
+    expect(url3.searchParams.get('LANGUAGE')).toEqual('nl');
     expect(url3.searchParams.get('LEGEND_OPTIONS')).toBeTruthy();
     const url4 = new URL(images[3].getAttribute('src') || '');
     expect(url4.host).toEqual('layer-4-weird-case-url');
     expect(url4.searchParams.get('SCALE')).toEqual('1000');
+    expect(url3.searchParams.get('LANGUAGE')).toEqual('nl');
     expect(url4.searchParams.get('LEGEND_OPTIONS')).toBeTruthy(); // Should be case-insensitive to REQUEST=GetLegendGrapic URL param
   });
 });

--- a/projects/core/src/lib/components/legend/legend/legend.component.spec.ts
+++ b/projects/core/src/lib/components/legend/legend/legend.component.spec.ts
@@ -10,6 +10,7 @@ import { BaseComponentTypeEnum, getAppLayerModel, getServiceModel } from '@tailo
 import { TestBed } from '@angular/core/testing';
 import { LegendLayerComponent } from '../legend-layer/legend-layer.component';
 import { getMapServiceMock } from '../../../test-helpers/map-service.mock.spec';
+import { LegendService } from '../services/legend.service';
 
 const createMockStore = () => {
   const layersAndServices = [
@@ -64,12 +65,10 @@ describe('LegendComponent', () => {
     const url3 = new URL(images[2].getAttribute('src') || '');
     expect(url3.host).toEqual('layer-3-url');
     expect(url3.searchParams.get('SCALE')).toEqual('1000');
-    expect(url3.searchParams.get('LANGUAGE')).toEqual('nl');
     expect(url3.searchParams.get('LEGEND_OPTIONS')).toBeTruthy();
     const url4 = new URL(images[3].getAttribute('src') || '');
     expect(url4.host).toEqual('layer-4-weird-case-url');
     expect(url4.searchParams.get('SCALE')).toEqual('1000');
-    expect(url3.searchParams.get('LANGUAGE')).toEqual('nl');
     expect(url4.searchParams.get('LEGEND_OPTIONS')).toBeTruthy(); // Should be case-insensitive to REQUEST=GetLegendGrapic URL param
   });
 });

--- a/projects/core/src/lib/components/legend/services/legend.service.ts
+++ b/projects/core/src/lib/components/legend/services/legend.service.ts
@@ -31,6 +31,9 @@ export class LegendService {
                 try {
                   const urlObject = new URL(url);
                   urlObject.searchParams.set('SCALE', mapResolution.scale.toString());
+                  if(this.mapService.getLocaleId() && layer.service?.serverType === 'geoserver') {
+                    urlObject.searchParams.set('LANGUAGE', this.mapService.getLocaleId());
+                  }
                   url = urlObject.toString();
                 } catch(_ignored) {
                   // Ignore errors

--- a/projects/core/src/lib/components/legend/services/legend.service.ts
+++ b/projects/core/src/lib/components/legend/services/legend.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@angular/core';
+import { Inject, Injectable, LOCALE_ID } from '@angular/core';
 import { catchError, combineLatest, concatMap, forkJoin, map, Observable, of, switchMap } from 'rxjs';
 import { MapService, MapViewDetailsModel, ScaleHelper } from '@tailormap-viewer/map';
 import { ExtendedAppLayerModel } from '../../../map/models';
@@ -13,6 +13,7 @@ export class LegendService {
 
   constructor(
     private mapService: MapService,
+    @Inject(LOCALE_ID) private localeId: string,
   ) {
   }
 
@@ -31,8 +32,8 @@ export class LegendService {
                 try {
                   const urlObject = new URL(url);
                   urlObject.searchParams.set('SCALE', mapResolution.scale.toString());
-                  if(this.mapService.getLocaleId() && layer.service?.serverType === 'geoserver') {
-                    urlObject.searchParams.set('LANGUAGE', this.mapService.getLocaleId());
+                  if(this.localeId && layer.service?.serverType === 'geoserver') {
+                    urlObject.searchParams.set('LANGUAGE', this.localeId);
                   }
                   url = urlObject.toString();
                 } catch(_ignored) {

--- a/projects/core/src/lib/map/services/application-map.service.ts
+++ b/projects/core/src/lib/map/services/application-map.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, OnDestroy } from '@angular/core';
+import { Inject, Injectable, LOCALE_ID, OnDestroy } from '@angular/core';
 import { Store } from '@ngrx/store';
 import {
   LayerModel, LayerTypesEnum, MapService, OgcHelper, ServiceLayerModel, WMSLayerModel, WMTSLayerModel, XyzLayerModel,
@@ -29,6 +29,7 @@ export class ApplicationMapService implements OnDestroy {
     private httpClient: HttpClient,
     private bookmarkService: BookmarkService,
     _applicationRefreshService: ApplicationLayerRefreshService,
+    @Inject(LOCALE_ID) private localeId: string,
   ) {
     const isValidLayer = (layer: LayerModel | null): layer is LayerModel => layer !== null;
     this.store$.select(selectMapOptions)
@@ -140,7 +141,7 @@ export class ApplicationMapService implements OnDestroy {
         tilingDisabled: extendedAppLayer.tilingDisabled,
         tilingGutter: extendedAppLayer.tilingGutter,
         filter: extendedAppLayer.filter,
-        language: service.serverType === ServerType.GEOSERVER ? this.mapService.getLocaleId() : undefined,
+        language: service.serverType === ServerType.GEOSERVER ? this.localeId : undefined,
       };
       return of(layer);
     }

--- a/projects/core/src/lib/map/services/application-map.service.ts
+++ b/projects/core/src/lib/map/services/application-map.service.ts
@@ -4,7 +4,7 @@ import {
   LayerModel, LayerTypesEnum, MapService, OgcHelper, ServiceLayerModel, WMSLayerModel, WMTSLayerModel, XyzLayerModel,
 } from '@tailormap-viewer/map';
 import { combineLatest, concatMap, distinctUntilChanged, filter, forkJoin, map, Observable, of, Subject, take, takeUntil, tap } from 'rxjs';
-import { ServiceModel, ServiceProtocol } from '@tailormap-viewer/api';
+import { ServerType, ServiceModel, ServiceProtocol } from '@tailormap-viewer/api';
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { ArrayHelper, HtmlifyHelper } from '@tailormap-viewer/shared';
 import { selectMapOptions, selectOrderedVisibleBackgroundLayers, selectOrderedVisibleLayersWithServices } from '../state/map.selectors';
@@ -140,6 +140,7 @@ export class ApplicationMapService implements OnDestroy {
         tilingDisabled: extendedAppLayer.tilingDisabled,
         tilingGutter: extendedAppLayer.tilingGutter,
         filter: extendedAppLayer.filter,
+        language: service.serverType === ServerType.GEOSERVER ? this.mapService.getLocaleId() : undefined,
       };
       return of(layer);
     }

--- a/projects/core/src/lib/test-helpers/map-service.mock.spec.ts
+++ b/projects/core/src/lib/test-helpers/map-service.mock.spec.ts
@@ -41,7 +41,6 @@ export const getMapServiceMock = (
     zoomToInitialExtent: jest.fn(),
     getProjectionCode$: jest.fn(() => of(projectionCode || 'EPSG:4326')),
     getLayerManager$: jest.fn(() => of({ getLegendUrl: (layerId: string) => `layer-${layerId}-url-from-service` })),
-    getLocaleId: jest.fn(() => 'nl'),
     ...overrides,
   };
   return {

--- a/projects/core/src/lib/test-helpers/map-service.mock.spec.ts
+++ b/projects/core/src/lib/test-helpers/map-service.mock.spec.ts
@@ -41,6 +41,7 @@ export const getMapServiceMock = (
     zoomToInitialExtent: jest.fn(),
     getProjectionCode$: jest.fn(() => of(projectionCode || 'EPSG:4326')),
     getLayerManager$: jest.fn(() => of({ getLegendUrl: (layerId: string) => `layer-${layerId}-url-from-service` })),
+    getLocaleId: jest.fn(() => 'nl'),
     ...overrides,
   };
   return {

--- a/projects/map/src/lib/helpers/ol-layer.helper.ts
+++ b/projects/map/src/lib/helpers/ol-layer.helper.ts
@@ -27,6 +27,7 @@ export interface LayerProperties {
   visible: boolean;
   name: string;
   filter?: string;
+  language?: string;
 }
 
 interface WmsServiceParamsModel {
@@ -36,6 +37,7 @@ interface WmsServiceParamsModel {
   TRANSPARENT: string;
   CQL_FILTER?: string;
   CACHE?: number;
+  LANGUAGE?: string;
 }
 
 const MAX_URL_LENGTH_BEFORE_POST = 4096;
@@ -318,6 +320,9 @@ export class OlLayerHelper {
     if (layer.filter && layer.serverType === TMServerType.GEOSERVER) {
       // TODO: implement filtering for other servers than geoserver (transform CQL to SLD for SLD_BODY param)
       params.CQL_FILTER = layer.filter;
+    }
+    if (layer.serverType === TMServerType.GEOSERVER && layer.language) {
+      params.LANGUAGE = layer.language;
     }
     if (addCacheBust) {
       params.CACHE = Date.now();

--- a/projects/map/src/lib/map-service/map.service.ts
+++ b/projects/map/src/lib/map-service/map.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, NgZone } from '@angular/core';
+import { Inject, Injectable, LOCALE_ID, NgZone } from '@angular/core';
 import { OpenLayersMap } from '../openlayers-map/openlayers-map';
 import { combineLatest, finalize, map, Observable, take, tap } from 'rxjs';
 import {
@@ -45,6 +45,7 @@ export class MapService {
   constructor(
     private ngZone: NgZone,
     private httpXsrfTokenExtractor: HttpXsrfTokenExtractor,
+    @Inject(LOCALE_ID) private localeId: string,
   ) {
     this.map = new OpenLayersMap(this.ngZone, this.httpXsrfTokenExtractor);
   }
@@ -255,4 +256,7 @@ export class MapService {
     this.map.setPadding(padding);
   }
 
+  public getLocaleId(): string {
+    return this.localeId;
+  }
 }

--- a/projects/map/src/lib/map-service/map.service.ts
+++ b/projects/map/src/lib/map-service/map.service.ts
@@ -1,4 +1,4 @@
-import { Inject, Injectable, LOCALE_ID, NgZone } from '@angular/core';
+import { Injectable, NgZone } from '@angular/core';
 import { OpenLayersMap } from '../openlayers-map/openlayers-map';
 import { combineLatest, finalize, map, Observable, take, tap } from 'rxjs';
 import {
@@ -45,7 +45,6 @@ export class MapService {
   constructor(
     private ngZone: NgZone,
     private httpXsrfTokenExtractor: HttpXsrfTokenExtractor,
-    @Inject(LOCALE_ID) private localeId: string,
   ) {
     this.map = new OpenLayersMap(this.ngZone, this.httpXsrfTokenExtractor);
   }
@@ -254,9 +253,5 @@ export class MapService {
 
   public setPadding(padding: number[]) {
     this.map.setPadding(padding);
-  }
-
-  public getLocaleId(): string {
-    return this.localeId;
   }
 }

--- a/projects/map/src/lib/models/wms-layer.model.ts
+++ b/projects/map/src/lib/models/wms-layer.model.ts
@@ -7,4 +7,5 @@ export interface WMSLayerModel extends ServiceLayerModel {
   serverType: ServerType;
   tilingDisabled?: boolean;
   tilingGutter?: number;
+  language?: string;
 }


### PR DESCRIPTION
[![HTM-1060](https://badgen.net/badge/JIRA/HTM-1060/pink?icon=jira)](https://b3partners.atlassian.net/browse/HTM-1060) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=Tailormap&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

This adds eg `LANGUAGE=nl` to GeoServer `getMap` and `getlegendGraphic` requests


see also https://github.com/Tailormap/tailormap-data/pull/25 for the data 

[HTM-1060]: https://b3partners.atlassian.net/browse/HTM-1060?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ