### PR TITLE
SUPPORT-14902 | HTM-1424 : Change the tooltip position of the background layer dropdown options to "before" (from default "below")

### DIFF
--- a/projects/shared/src/lib/components/split-button/split-button.component.html
+++ b/projects/shared/src/lib/components/split-button/split-button.component.html
@@ -21,6 +21,7 @@
           class="split-button-menu-item"
           *ngFor="let option of optionsList"
           [tmTooltip]="option.label"
+          [matTooltipPosition]="'before'"
           (click)="selectOption(option.id)">
     <mat-icon svgIcon="check" *ngIf="option.id === selectedOptionId"></mat-icon>
     {{ option.label }}


### PR DESCRIPTION
[![SUPPORT-14902](https://badgen.net/badge/JIRA/SUPPORT-14902/pink?icon=jira)](https://b3partners.atlassian.net/browse/SUPPORT-14902) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=Tailormap&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

resolves https://b3partners.atlassian.net/browse/SUPPORT-14902