### PR TITLE
HTM-1430: Add warning messages when a feature type does not have a primary key and/or geometry attribute

### DIFF
--- a/projects/admin-core/assets/locale/messages.admin-core.de.xlf
+++ b/projects/admin-core/assets/locale/messages.admin-core.de.xlf
@@ -806,6 +806,14 @@
         <source>High-DPI substitute URL template</source>
         <target>High-DPI-Ersatz-URL-Vorlage</target>
       </trans-unit>
+      <trans-unit id="admin-core.catalog.feature-type-no-pk-warning" datatype="html">
+        <source>This feature type does not have a primary key.</source>
+        <target>Dieser Feature-Typ hat keinen Primärschlüssel.</target>
+      </trans-unit>
+      <trans-unit id=".feature-type-no-default-geom-warning" datatype="html">
+        <source>This feature type does not have a geometry attribute.</source>
+        <target>Dieser Feature-Typ hat kein Geometrieattribut.</target>
+      </trans-unit>
       <trans-unit id="admin-core.catalog.technical-name" datatype="html">
         <source>Technical name: <x id="INTERPOLATION" equiv-text="{{ featureType.name }}"/></source>
         <target state="translated">Technischer Name: <x id="INTERPOLATION" equiv-text="{{ featureType.name }}"/></target>

--- a/projects/admin-core/assets/locale/messages.admin-core.en.xlf
+++ b/projects/admin-core/assets/locale/messages.admin-core.en.xlf
@@ -605,6 +605,12 @@
       <trans-unit id="admin-core.catalog.substitute-layer-url-template" datatype="html">
         <source>High-DPI substitute URL template</source>
       </trans-unit>
+      <trans-unit id="admin-core.catalog.feature-type-no-pk-warning" datatype="html">
+        <source>This feature type does not have a primary key.</source>
+      </trans-unit>
+      <trans-unit id=".feature-type-no-default-geom-warning" datatype="html">
+        <source>This feature type does not have a geometry attribute.</source>
+      </trans-unit>
       <trans-unit id="admin-core.catalog.technical-name" datatype="html">
         <source>Technical name: <x id="INTERPOLATION" equiv-text="{{ featureType.name }}"/></source>
       </trans-unit>

--- a/projects/admin-core/assets/locale/messages.admin-core.nl.xlf
+++ b/projects/admin-core/assets/locale/messages.admin-core.nl.xlf
@@ -806,6 +806,14 @@
         <source>High-DPI substitute URL template</source>
         <target>High-DPI vervangend URL sjabloon</target>
       </trans-unit>
+      <trans-unit id="admin-core.catalog.feature-type-no-pk-warning" datatype="html">
+        <source>This feature type does not have a primary key.</source>
+        <target>Dit feature type heeft geen primaire sleutel.</target>
+      </trans-unit>
+      <trans-unit id=".feature-type-no-default-geom-warning" datatype="html">
+        <source>This feature type does not have a geometry attribute.</source>
+        <target>Dit feature type heeft geen geometrie attribuut.</target>
+      </trans-unit>
       <trans-unit id="admin-core.catalog.technical-name" datatype="html">
         <source>Technical name: <x id="INTERPOLATION" equiv-text="{{ featureType.name }}"/></source>
         <target>Technische naam: <x id="INTERPOLATION" equiv-text="{{ featureType.name }}"/></target>

--- a/projects/admin-core/src/lib/catalog/feature-type-form/feature-type-form.component.html
+++ b/projects/admin-core/src/lib/catalog/feature-type-form/feature-type-form.component.html
@@ -3,6 +3,17 @@
   <h2 *ngIf="dialogLayout" mat-dialog-title><ng-container *ngTemplateOutlet="title"></ng-container></h2>
   <h2 *ngIf="!dialogLayout" class="page-details-title"><ng-container *ngTemplateOutlet="title"></ng-container></h2>
 
+  @if (!featureType.primaryKeyAttribute) {
+    <tm-error-message [message]="'This feature type does not have a primary key.'"
+                      i18n-message="@@admin-core.catalog.feature-type-no-pk-warning" [friendlyError]="true">
+    </tm-error-message>
+  }
+  @if (!featureType.defaultGeometryAttribute) {
+    <tm-error-message [message]="'This feature type does not have a geometry attribute.'"
+                      i18n-message="@@admin-core.catalog.feature-type-no-default-geom-warning" [friendlyError]="true">
+    </tm-error-message>
+  }
+
   <ng-template #content>
     <div i18n="@@admin-core.catalog.technical-name">Technical name: {{ featureType.name }}</div>
     @defer {


### PR DESCRIPTION
[![HTM-1430](https://badgen.net/badge/JIRA/HTM-1430/pink?icon=jira)](https://b3partners.atlassian.net/browse/HTM-1430) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=Tailormap&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->



[HTM-1430]: https://b3partners.atlassian.net/browse/HTM-1430?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ