### PR TITLE
HTM-1388: Remove `jsdom-worker` dev dependency after OpenLayers upgrade

### DIFF
--- a/jest.base.config.js
+++ b/jest.base.config.js
@@ -1,7 +1,7 @@
 process.env.TZ = 'GMT';
 
 module.exports = {
-  setupFiles: ['jsdom-worker'],
+  setupFiles: [],
   preset: 'jest-preset-angular',
   setupFilesAfterEnv: ['<rootDir>/../../setup-jest.ts'],
   "testRegex": "((\\.|/*.)(spec))\\.ts?$",

--- a/package-lock.json
+++ b/package-lock.json
@@ -81,7 +81,6 @@
         "jest-fail-on-console": "^3.3.1",
         "jest-junit": "^16.0.0",
         "jest-preset-angular": "^14.5.0",
-        "jsdom-worker": "^0.3.0",
         "ng-extract-i18n-merge": "^2.13.1",
         "ng-packagr": "^19.1.0",
         "ts-jest": "^29.2.5",
@@ -16875,19 +16874,6 @@
         "node": ">=12.0.0"
       }
     },
-    "node_modules/jsdom-worker": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/jsdom-worker/-/jsdom-worker-0.3.0.tgz",
-      "integrity": "sha512-nlPmN0i93+e6vxzov8xqLMR+MBs/TAYeSviehivzqovHH0AgooVx9pQ/otrygASppPvdR+V9Jqx5SMe8+FcADg==",
-      "dev": true,
-      "dependencies": {
-        "mitt": "^3.0.0",
-        "uuid-v4": "^0.1.0"
-      },
-      "peerDependencies": {
-        "node-fetch": "*"
-      }
-    },
     "node_modules/jsesc": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
@@ -18826,12 +18812,6 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
-    },
-    "node_modules/mitt": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
-      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
-      "dev": true
     },
     "node_modules/mkdirp": {
       "version": "1.0.4",
@@ -23711,15 +23691,6 @@
       "dev": true,
       "bin": {
         "uuid": "dist/bin/uuid"
-      }
-    },
-    "node_modules/uuid-v4": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/uuid-v4/-/uuid-v4-0.1.0.tgz",
-      "integrity": "sha512-m11RYDtowtAIihBXMoGajOEKpAXrKbpKlpmxqyztMYQNGSY5nZAZ/oYch/w2HNS1RMA4WLGcZvuD8/wFMuCEzA==",
-      "dev": true,
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/v8-to-istanbul": {
@@ -36453,16 +36424,6 @@
       "integrity": "sha512-YtOli5Cmzy3q4dP26GraSOeAhqecewG04hoO8DY56CH4KJ9Fvv5qKWUCCo3HZob7esJQHCv6/+bnTy72xZZaVQ==",
       "dev": true
     },
-    "jsdom-worker": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/jsdom-worker/-/jsdom-worker-0.3.0.tgz",
-      "integrity": "sha512-nlPmN0i93+e6vxzov8xqLMR+MBs/TAYeSviehivzqovHH0AgooVx9pQ/otrygASppPvdR+V9Jqx5SMe8+FcADg==",
-      "dev": true,
-      "requires": {
-        "mitt": "^3.0.0",
-        "uuid-v4": "^0.1.0"
-      }
-    },
     "jsesc": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
@@ -37779,12 +37740,6 @@
           }
         }
       }
-    },
-    "mitt": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
-      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
-      "dev": true
     },
     "mkdirp": {
       "version": "1.0.4",
@@ -41366,12 +41321,6 @@
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "dev": true
-    },
-    "uuid-v4": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/uuid-v4/-/uuid-v4-0.1.0.tgz",
-      "integrity": "sha512-m11RYDtowtAIihBXMoGajOEKpAXrKbpKlpmxqyztMYQNGSY5nZAZ/oYch/w2HNS1RMA4WLGcZvuD8/wFMuCEzA==",
       "dev": true
     },
     "v8-to-istanbul": {

--- a/package.json
+++ b/package.json
@@ -104,7 +104,6 @@
     "jest-fail-on-console": "^3.3.1",
     "jest-junit": "^16.0.0",
     "jest-preset-angular": "^14.5.0",
-    "jsdom-worker": "^0.3.0",
     "ng-extract-i18n-merge": "^2.13.1",
     "ng-packagr": "^19.1.0",
     "ts-jest": "^29.2.5",


### PR DESCRIPTION
[![HTM-1388](https://badgen.net/badge/JIRA/HTM-1388/pink?icon=jira)](https://b3partners.atlassian.net/browse/HTM-1388) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=Tailormap&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

OpenLayers was upgraded  in https://github.com/Tailormap/tailormap-viewer/pull/812

[HTM-1388]: https://b3partners.atlassian.net/browse/HTM-1388?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ