### PR TITLE
Fixes HTM-1440: only show filterable layers with attributes

### DIFF
--- a/projects/core/src/lib/map/state/map.selectors.ts
+++ b/projects/core/src/lib/map/state/map.selectors.ts
@@ -125,7 +125,7 @@ export const selectVisibleWMSLayersWithoutAttributes = createSelector(
 
 export const selectFilterableLayers = createSelector(
   selectOrderedVisibleLayersWithServices,
-  layers => layers.filter(l => l.service?.serverType === ServerType.GEOSERVER),
+  layers => layers.filter(l => l.service?.serverType === ServerType.GEOSERVER && l.hasAttributes),
 );
 
 export const selectSomeLayersVisible = createSelector(


### PR DESCRIPTION
[![HTM-1440](https://badgen.net/badge/JIRA/HTM-1440/pink?icon=jira)](https://b3partners.atlassian.net/browse/HTM-1440) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=Tailormap&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Because the geometry attribute name is required to create CQL filters.

[HTM-1440]: https://b3partners.atlassian.net/browse/HTM-1440?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ