### PR TITLE
HTM-1443: show key icon next to primary key attribute

### DIFF
--- a/projects/admin-core/assets/locale/messages.admin-core.de.xlf
+++ b/projects/admin-core/assets/locale/messages.admin-core.de.xlf
@@ -706,6 +706,10 @@
         <source>Port</source>
         <target>Port</target>
       </trans-unit>
+      <trans-unit id="admin-core.catalog.primary-key" datatype="html">
+        <source>Primary key</source>
+        <target>Primärschlüssel</target>
+      </trans-unit>
       <trans-unit id="admin-core.catalog.protocol" datatype="html">
         <source>Protocol</source>
         <target>Protokoll</target>

--- a/projects/admin-core/assets/locale/messages.admin-core.en.xlf
+++ b/projects/admin-core/assets/locale/messages.admin-core.en.xlf
@@ -530,6 +530,9 @@
       <trans-unit id="admin-core.catalog.port" datatype="html">
         <source>Port</source>
       </trans-unit>
+      <trans-unit id="admin-core.catalog.primary-key" datatype="html">
+        <source>Primary key</source>
+      </trans-unit>
       <trans-unit id="admin-core.catalog.protocol" datatype="html">
         <source>Protocol</source>
       </trans-unit>

--- a/projects/admin-core/assets/locale/messages.admin-core.nl.xlf
+++ b/projects/admin-core/assets/locale/messages.admin-core.nl.xlf
@@ -706,6 +706,10 @@
         <source>Port</source>
         <target>Poort</target>
       </trans-unit>
+      <trans-unit id="admin-core.catalog.primary-key" datatype="html">
+        <source>Primary key</source>
+        <target>Primaire sleutel</target>
+      </trans-unit>
       <trans-unit id="admin-core.catalog.protocol" datatype="html">
         <source>Protocol</source>
         <target>Protocol</target>

--- a/projects/admin-core/src/lib/catalog/feature-type-attributes/feature-type-attributes.component.html
+++ b/projects/admin-core/src/lib/catalog/feature-type-attributes/feature-type-attributes.component.html
@@ -36,7 +36,12 @@
           <ng-container matColumnDef="name">
             <mat-header-cell *matHeaderCellDef></mat-header-cell>
             <mat-cell *matCellDef="let att" [class.disabled-cell]="isReadonlyFieldDisabled(att.name)">
-              <div class="wrap-text" [tmTooltip]="att.name">{{att.name}}</div>
+              <div class="wrap-text" [tmTooltip]="att.name + (att.name === primaryKeyAttributeName ? ' (' + primaryKeyText + ')' : '')">
+                {{att.name}}
+                @if(att.name === primaryKeyAttributeName) {
+                  <mat-icon svgIcon="key" class="key-icon" style="transform: rotate(90deg); display: inline-block; vertical-align: middle"></mat-icon>
+                }
+              </div>
             </mat-cell>
           </ng-container>
           <ng-container matColumnDef="type">

--- a/projects/admin-core/src/lib/catalog/feature-type-attributes/feature-type-attributes.component.ts
+++ b/projects/admin-core/src/lib/catalog/feature-type-attributes/feature-type-attributes.component.ts
@@ -32,6 +32,9 @@ export class FeatureTypeAttributesComponent implements OnChanges {
   public attributes: AttributeDescriptorModel[] = [];
 
   @Input()
+  public primaryKeyAttributeName: string | null = null;
+
+  @Input()
   public featureTypeSettings: FeatureTypeSettingsModel | null = null;
 
   @Input()
@@ -51,6 +54,8 @@ export class FeatureTypeAttributesComponent implements OnChanges {
     return this._showFullSettings;
   }
   private _showFullSettings = false;
+
+  public primaryKeyText = $localize `:@@admin-core.catalog.primary-key:Primary key`;
 
   @Output()
   public attributeEnabledChanged = new EventEmitter<Array<{ attribute: string; checked: boolean }>>();

--- a/projects/admin-core/src/lib/catalog/feature-type-form/feature-type-form.component.html
+++ b/projects/admin-core/src/lib/catalog/feature-type-form/feature-type-form.component.html
@@ -22,6 +22,7 @@
                                       (templateUpdated)="templateUpdated($event)"></tm-admin-feature-type-template>
     }
     <tm-admin-feature-type-attributes [attributes]="featureType.attributes"
+                                      [primaryKeyAttributeName]="featureType.primaryKeyAttribute"
                                       [featureTypeSettings]="featureTypeSettings$ | async"
                                       [showFullSettings]="true"
                                       (attributeEnabledChanged)="attributeEnabledChanged(featureType.settings, $event)"


### PR DESCRIPTION
[![HTM-1443](https://badgen.net/badge/JIRA/HTM-1443/pink?icon=jira)](https://b3partners.atlassian.net/browse/HTM-1443) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=Tailormap&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

- [ ] The `FeatureTypeAttributesComponent` is also used in the `ApplicationLayerAttributeSettingsComponent`, but the primary key icon isn't shown there.

[HTM-1443]: https://b3partners.atlassian.net/browse/HTM-1443?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ