### PR TITLE
⛓️‍💥 EK-15: replace the PostgreSQL 15 image with a PostGIS 17-3.5 image ⛓️‍💥

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,8 +18,11 @@ updates:
       time: '21:00'
       timezone: 'Europe/Amsterdam'
     target-branch: main
+    commit-message:
+      prefix: "🐳 "
     labels:
       - infrastructure
+      - docker-update
     ignore:
       - dependency-name: node
         versions:
@@ -33,5 +36,22 @@ updates:
       time: '21:00'
       timezone: 'Europe/Amsterdam'
     target-branch: main
+    commit-message:
+      prefix: "🐳 "
     labels:
+      - infrastructure
+      - docker-update
+
+  - package-ecosystem: "docker-compose"
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: '21:00'
+      timezone: 'Europe/Amsterdam'
+    commit-message:
+      prefix: "⛓️‍💥 "
+    labels:
+      - breaking
+      - docker-update
       - infrastructure

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,7 +52,7 @@ services:
 
   db:
     container_name: ${COMPOSE_PROJECT_NAME}-db
-    image: postgres:15.8-alpine3.20
+    image: postgis/postgis:17-3.5-alpine
     environment:
       POSTGRES_PASSWORD: ${TAILORMAP_DB_PASSWORD:-tailormap}
       POSTGRES_USER: tailormap


### PR DESCRIPTION
[![EK-15](https://badgen.net/badge/JIRA/EK-15/pink?icon=jira)](https://b3partners.atlassian.net/browse/EK-15) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=Tailormap&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

To support storing drawings.

**THIS IS A BREAKING CHANGE; it requires a full dump and restore of the Tailormap database** as this is a major database version bump. The procedure is described in detail in the README: [Backing up the configuration database](https://github.com/Tailormap/tailormap-viewer?tab=readme-ov-file#backing-up-the-configuration-database), [Restoring a backup](https://github.com/Tailormap/tailormap-viewer?tab=readme-ov-file#restoring-a-backup) and [Upgrading to a new major PostgreSQL version
](https://github.com/Tailormap/tailormap-viewer?tab=readme-ov-file#upgrading-to-a-new-major-postgresql-version)

[EK-15]: https://b3partners.atlassian.net/browse/EK-15?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ