### PR TITLE
HTM-1453, HTM-1454: Fix catalog node warnings

### DIFF
--- a/projects/admin-core/src/lib/catalog/catalog-base-tree/catalog-base-tree-node/catalog-base-tree-node.component.ts
+++ b/projects/admin-core/src/lib/catalog/catalog-base-tree/catalog-base-tree-node/catalog-base-tree-node.component.ts
@@ -38,20 +38,19 @@ export class CatalogBaseTreeNodeComponent {
     this._node = node;
     this.nodeSettings.label = CatalogBaseTreeNodeComponent.nodeLabel[node?.type || 'unknown'] || '';
     this.nodeSettings.icon = CatalogBaseTreeNodeComponent.getNodeIcon(node);
+    const warnings = [];
 
     if (node?.type && node.type === CatalogTreeModelTypeEnum.FEATURE_TYPE_TYPE && node.metadata ) {
       const metadata: ExtendedFeatureTypeModel = node.metadata as ExtendedFeatureTypeModel;
-      this.nodeSettings.warningMsg = '';
+
       if (metadata.defaultGeometryAttribute === null) {
-        this.nodeSettings.warningMsg += $localize `:@@admin-core.catalog.feature-type-no-default-geom-warning:This feature type does not have a geometry attribute.`;
+        warnings.push($localize `:@@admin-core.catalog.feature-type-no-default-geom-warning:This feature type does not have a geometry attribute.`);
       }
-      if (metadata.featureSourceProtocol === 'WFS' && metadata.primaryKeyAttribute === null) {
-        if (this.nodeSettings.warningMsg.length > 0) {
-          this.nodeSettings.warningMsg += '\n';
-        }
-        this.nodeSettings.warningMsg += $localize `:@@admin-core.catalog.feature-type-no-pk-warning:This feature type does not have a primary key.`;
+      if (metadata.featureSourceProtocol !== 'WFS' && metadata.primaryKeyAttribute === null) {
+         warnings.push($localize `:@@admin-core.catalog.feature-type-no-pk-warning:This feature type does not have a primary key.`);
       }
     }
+    this.nodeSettings.warningMsg = warnings.join('\n');
   }
   public get node(): CatalogTreeModel | null {
     return this._node;

--- a/projects/admin-core/src/lib/catalog/catalog-base-tree/catalog-base-tree-node/catalog-base-tree-node.component.ts
+++ b/projects/admin-core/src/lib/catalog/catalog-base-tree/catalog-base-tree-node/catalog-base-tree-node.component.ts
@@ -38,9 +38,9 @@ export class CatalogBaseTreeNodeComponent {
     this._node = node;
     this.nodeSettings.label = CatalogBaseTreeNodeComponent.nodeLabel[node?.type || 'unknown'] || '';
     this.nodeSettings.icon = CatalogBaseTreeNodeComponent.getNodeIcon(node);
-    const warnings = [];
 
-    if (node?.type && node.type === CatalogTreeModelTypeEnum.FEATURE_TYPE_TYPE && node.metadata ) {
+    const warnings = [];
+    if (node?.type === CatalogTreeModelTypeEnum.FEATURE_TYPE_TYPE && node.metadata ) {
       const metadata: ExtendedFeatureTypeModel = node.metadata as ExtendedFeatureTypeModel;
 
       if (metadata.defaultGeometryAttribute === null) {


### PR DESCRIPTION
[![HTM-1453](https://badgen.net/badge/JIRA/HTM-1453/pink?icon=jira)](https://b3partners.atlassian.net/browse/HTM-1453) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=Tailormap&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Note: the primary key warning is still shown for WFS feature types in the `FeatureTypeFormComponent`, but as you need the feature source protocol this is easier to change in #820 : 51ef50a2f6adca6f88bca8914266acfbf55de309


[HTM-1453]: https://b3partners.atlassian.net/browse/HTM-1453?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ