### PR TITLE
HTM-1189: increase the WMS getFeatureInfo maximum features count from 1 (default) to 10

### DIFF
--- a/projects/map/src/lib/openlayers-map/helpers/open-layers-wms-get-feature-info.helper.ts
+++ b/projects/map/src/lib/openlayers-map/helpers/open-layers-wms-get-feature-info.helper.ts
@@ -37,6 +37,7 @@ export class OpenLayersWmsGetFeatureInfoHelper {
     const url = source.getFeatureInfoUrl(coordinates, resolution, projection, {
       INFO_FORMAT: 'application/json',
       QUERY_LAYERS: queryLayers,
+      FEATURE_COUNT: 10,
     });
     if (!url) {
       return of([]);


### PR DESCRIPTION
[![HTM-1189](https://badgen.net/badge/JIRA/HTM-1189/pink?icon=jira)](https://b3partners.atlassian.net/browse/HTM-1189) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=Tailormap&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

A maximum of 10 features per layer is an arbitrary choice; in the past this is a number that proved to perform well

[HTM-1189]: https://b3partners.atlassian.net/browse/HTM-1189?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ