### PR TITLE
HTM-1489: Fixes click tool always being enabled

### DIFF
--- a/projects/map/src/lib/map-service/map.service.ts
+++ b/projects/map/src/lib/map-service/map.service.ts
@@ -261,11 +261,11 @@ export class MapService {
   }
 
   public make3D(){
-    this.map.make3D();
+    this.map.make3d();
   }
 
   public switch3D(){
-    this.map.switch3D();
+    this.map.switch3d();
   }
 
 }

--- a/projects/map/src/lib/openlayers-map/open-layers-event-manager.spec.ts
+++ b/projects/map/src/lib/openlayers-map/open-layers-event-manager.spec.ts
@@ -1,4 +1,5 @@
 import { OpenLayersEventManager } from './open-layers-event-manager';
+import { of } from 'rxjs';
 
 const ngZoneRunFn = jest.fn((cb: () => void) => cb());
 const mockNgZone = { run: ngZoneRunFn } as any;
@@ -10,7 +11,7 @@ describe('OpenLayersEventManager', () => {
     const olMap = {
       on: onFn,
     };
-    OpenLayersEventManager.initEvents(olMap as any, mockNgZone);
+    OpenLayersEventManager.initEvents(olMap as any, mockNgZone, of(false));
     expect(onFn).toHaveBeenCalled();
   });
 
@@ -20,7 +21,7 @@ describe('OpenLayersEventManager', () => {
     const olMap = {
       on: onFn,
     };
-    OpenLayersEventManager.initEvents(olMap as any, mockNgZone);
+    OpenLayersEventManager.initEvents(olMap as any, mockNgZone, of(false));
     expect(onFn).toHaveBeenCalled();
     OpenLayersEventManager.onMapMove$().subscribe(e => {
       expect(e).toEqual('test');
@@ -37,7 +38,7 @@ describe('OpenLayersEventManager', () => {
     const olMap = {
       on: onFn,
     };
-    OpenLayersEventManager.initEvents(olMap as any, mockNgZone);
+    OpenLayersEventManager.initEvents(olMap as any, mockNgZone, of(false));
     expect(onFn).toHaveBeenCalled();
     OpenLayersEventManager.onMapClick$().subscribe(e => {
       expect(e).toEqual('test_click');
@@ -46,6 +47,26 @@ describe('OpenLayersEventManager', () => {
     const moveEndReg = onFn.mock.calls.find(c => c[0] === 'singleclick');
     moveEndReg[1]('test_click');
     expect(ngZoneRunFn).toHaveBeenCalled();
+  });
+
+  test('does not trigger onClick events when in 3D', () => {
+    jest.useFakeTimers();
+    ngZoneRunFn.mockClear();
+    const onFn = jest.fn();
+    const olMap = {
+      on: onFn,
+    };
+    OpenLayersEventManager.initEvents(olMap as any, mockNgZone, of(true));
+    expect(onFn).toHaveBeenCalled();
+    let emitted = false;
+    OpenLayersEventManager.onMapClick$().subscribe(() => emitted = true);
+    const moveEndReg = onFn.mock.calls.find(c => c[0] === 'singleclick');
+    moveEndReg[1]('test_click');
+    expect(ngZoneRunFn).toHaveBeenCalled();
+    jest.runAllTimers();
+    jest.advanceTimersByTime(1000);
+    expect(emitted).toEqual(false);
+    jest.useRealTimers();
   });
 
 });

--- a/projects/map/src/lib/openlayers-map/open-layers-event-manager.ts
+++ b/projects/map/src/lib/openlayers-map/open-layers-event-manager.ts
@@ -23,34 +23,34 @@ export class OpenLayersEventManager {
   private static mapClickEvent: EventManagerEvent<MapBrowserEvent<MouseEvent>> = { stream: new Subject<MapBrowserEvent<MouseEvent>>() };
   private static mouseMoveEvent: EventManagerEvent<MapBrowserEvent<MouseEvent>> = { stream: new Subject<MapBrowserEvent<MouseEvent>>() };
   private static changeViewEvent: EventManagerEvent<ObjectEvent> = { stream: new Subject<ObjectEvent>() };
-  private static in3D = false;
+  private static in3d = false;
   private static destroyed = new Subject();
 
   public static initEvents(
     olMap: OlMap,
     ngZone: NgZone,
-    in3D$: Observable<boolean>,
+    in3d$: Observable<boolean>,
   ) {
     OpenLayersEventManager.destroyed = new Subject();
     OpenLayersEventManager.registerEvent(olMap, ngZone, 'moveend', OpenLayersEventManager.mapMoveEndEvent);
     OpenLayersEventManager.registerEvent(olMap, ngZone, 'singleclick', OpenLayersEventManager.mapClickEvent);
     OpenLayersEventManager.registerEvent(olMap, ngZone, 'pointermove', OpenLayersEventManager.mouseMoveEvent);
     OpenLayersEventManager.registerEvent(olMap, ngZone, 'change:view', OpenLayersEventManager.changeViewEvent);
-    in3D$
+    in3d$
       .pipe(takeUntil(OpenLayersEventManager.destroyed))
-      .subscribe(in3D => OpenLayersEventManager.in3D = in3D);
+      .subscribe(in3d => OpenLayersEventManager.in3d = in3d);
   }
 
   public static destroy() {
     OpenLayersEventManager.destroyed.next(true);
     OpenLayersEventManager.destroyed.complete();
-    OpenLayersEventManager.deRegisterEvent(OpenLayersEventManager.mapMoveEndEvent);
-    OpenLayersEventManager.deRegisterEvent(OpenLayersEventManager.mapClickEvent);
-    OpenLayersEventManager.deRegisterEvent(OpenLayersEventManager.mouseMoveEvent);
-    OpenLayersEventManager.deRegisterEvent(OpenLayersEventManager.changeViewEvent);
+    OpenLayersEventManager.deregisterEvent(OpenLayersEventManager.mapMoveEndEvent);
+    OpenLayersEventManager.deregisterEvent(OpenLayersEventManager.mapClickEvent);
+    OpenLayersEventManager.deregisterEvent(OpenLayersEventManager.mouseMoveEvent);
+    OpenLayersEventManager.deregisterEvent(OpenLayersEventManager.changeViewEvent);
   }
 
-  private static deRegisterEvent<EventType extends BaseEvent>(event: EventManagerEvent<EventType>) {
+  private static deregisterEvent<EventType extends BaseEvent>(event: EventManagerEvent<EventType>) {
     if (event.eventKey) {
       unByKey(event.eventKey);
     }
@@ -62,7 +62,7 @@ export class OpenLayersEventManager {
     evtKey: OlEventType,
     event: EventManagerEvent<EventType>,
   ) {
-    OpenLayersEventManager.deRegisterEvent(event);
+    OpenLayersEventManager.deregisterEvent(event);
     event.eventKey = olMap.on(
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore - for some weird reason TS won't recognize the type of evtKey and sees it as string
@@ -77,7 +77,7 @@ export class OpenLayersEventManager {
 
   public static onMapClick$(): Observable<MapBrowserEvent<MouseEvent>> {
     return OpenLayersEventManager.mapClickEvent.stream.asObservable()
-      .pipe(filter(() => !OpenLayersEventManager.in3D));
+      .pipe(filter(() => !OpenLayersEventManager.in3d));
   }
 
   public static onMouseMove$(): Observable<MapBrowserEvent<MouseEvent>> {

--- a/projects/map/src/lib/openlayers-map/open-layers-event-manager.ts
+++ b/projects/map/src/lib/openlayers-map/open-layers-event-manager.ts
@@ -1,13 +1,12 @@
 import { Map as OlMap } from 'ol';
 import { NgZone } from '@angular/core';
-import { BehaviorSubject, Observable, Subject, takeUntil, combineLatest, filter } from 'rxjs';
+import { Observable, Subject, takeUntil, filter } from 'rxjs';
 import { default as MapEvent } from 'ol/MapEvent';
 import { default as BaseEvent } from 'ol/events/Event';
 import { EventsKey } from 'ol/events';
 import { unByKey } from 'ol/Observable';
 import { MapBrowserEvent } from 'ol';
 import { ObjectEvent } from 'ol/Object';
-import { withLatestFrom } from 'rxjs/operators';
 
 type OlEventType = 'change' | 'error' | 'click' | 'dblclick' | 'pointermove' | 'singleclick' | 'pointerdrag'
   | 'movestart' | 'moveend' | 'propertychange' | 'change:layergroup' | 'change:size' | 'change:target' | 'change:view'
@@ -24,7 +23,7 @@ export class OpenLayersEventManager {
   private static mapClickEvent: EventManagerEvent<MapBrowserEvent<MouseEvent>> = { stream: new Subject<MapBrowserEvent<MouseEvent>>() };
   private static mouseMoveEvent: EventManagerEvent<MapBrowserEvent<MouseEvent>> = { stream: new Subject<MapBrowserEvent<MouseEvent>>() };
   private static changeViewEvent: EventManagerEvent<ObjectEvent> = { stream: new Subject<ObjectEvent>() };
-  private static in3D$: BehaviorSubject<boolean> = new BehaviorSubject(false);
+  private static in3D = false;
   private static destroyed = new Subject();
 
   public static initEvents(
@@ -39,7 +38,7 @@ export class OpenLayersEventManager {
     OpenLayersEventManager.registerEvent(olMap, ngZone, 'change:view', OpenLayersEventManager.changeViewEvent);
     in3D$
       .pipe(takeUntil(OpenLayersEventManager.destroyed))
-      .subscribe(in3D => OpenLayersEventManager.in3D$.next(in3D));
+      .subscribe(in3D => OpenLayersEventManager.in3D = in3D);
   }
 
   public static destroy() {
@@ -78,7 +77,7 @@ export class OpenLayersEventManager {
 
   public static onMapClick$(): Observable<MapBrowserEvent<MouseEvent>> {
     return OpenLayersEventManager.mapClickEvent.stream.asObservable()
-      .pipe(filter(() => !OpenLayersEventManager.in3D$.value));
+      .pipe(filter(() => !OpenLayersEventManager.in3D));
   }
 
   public static onMouseMove$(): Observable<MapBrowserEvent<MouseEvent>> {

--- a/projects/map/src/lib/openlayers-map/open-layers-tool-manager.ts
+++ b/projects/map/src/lib/openlayers-map/open-layers-tool-manager.ts
@@ -8,7 +8,7 @@ import { OpenLayersMousePositionTool } from './tools/open-layers-mouse-position-
 import { OpenLayersScaleBarTool } from './tools/open-layers-scale-bar-tool';
 import { OpenLayersSelectTool } from './tools/open-layers-select-tool';
 import { OpenLayersModifyTool } from "./tools/open-layers-modify-tool";
-import { Observable, Subject } from 'rxjs';
+import { Subject } from 'rxjs';
 
 export class OpenLayersToolManager implements ToolManagerModel {
 
@@ -25,7 +25,6 @@ export class OpenLayersToolManager implements ToolManagerModel {
   constructor(
     private olMap: OlMap,
     private ngZone: NgZone,
-    private in3D$: Observable<boolean>,
   ) {
   }
 
@@ -40,7 +39,7 @@ export class OpenLayersToolManager implements ToolManagerModel {
   public addTool<T extends ToolModel, C extends ToolConfigModel>(tool: C): T {
     const toolId = `${tool.type.toLowerCase()}-${++OpenLayersToolManager.toolIdCount}`;
     if (ToolTypeHelper.isMapClickTool(tool)) {
-      this.tools.set(toolId, new OpenLayersMapClickTool(toolId, tool, this.in3D$));
+      this.tools.set(toolId, new OpenLayersMapClickTool(toolId, tool));
     }
     if (ToolTypeHelper.isDrawingTool(tool)) {
       this.tools.set(toolId, new OpenLayersDrawingTool(toolId, tool, this.olMap, this.ngZone));

--- a/projects/map/src/lib/openlayers-map/openlayers-map.ts
+++ b/projects/map/src/lib/openlayers-map/openlayers-map.ts
@@ -116,10 +116,12 @@ export class OpenLayersMap implements MapViewerModel {
       this.map.value.dispose();
     }
 
+    OpenLayersEventManager.destroy();
+
     const layerManager = new OpenLayersLayerManager(olMap, this.ngZone, this.httpXsrfTokenExtractor);
     layerManager.init();
-    const toolManager = new OpenLayersToolManager(olMap, this.ngZone, this.in3D);
-    OpenLayersEventManager.initEvents(olMap, this.ngZone);
+    const toolManager = new OpenLayersToolManager(olMap, this.ngZone);
+    OpenLayersEventManager.initEvents(olMap, this.ngZone, this.in3D);
 
     this.map.next(olMap);
     this.layerManager.next(layerManager);

--- a/projects/map/src/lib/openlayers-map/openlayers-map.ts
+++ b/projects/map/src/lib/openlayers-map/openlayers-map.ts
@@ -33,9 +33,9 @@ export class OpenLayersMap implements MapViewerModel {
   private layerManager: BehaviorSubject<OpenLayersLayerManager | null> = new BehaviorSubject<OpenLayersLayerManager | null>(null);
   private toolManager: BehaviorSubject<ToolManagerModel | null> = new BehaviorSubject<ToolManagerModel | null>(null);
 
-  private map3D: BehaviorSubject<CesiumManager | null> = new BehaviorSubject<CesiumManager | null>(null);
-  private made3D: boolean;
-  private in3D: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(false);
+  private map3d: BehaviorSubject<CesiumManager | null> = new BehaviorSubject<CesiumManager | null>(null);
+  private made3d: boolean;
+  private in3d: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(false);
 
   private readonly resizeObserver: ResizeObserver;
   private initialExtent: OpenlayersExtent = [];
@@ -47,7 +47,7 @@ export class OpenLayersMap implements MapViewerModel {
     private httpXsrfTokenExtractor: HttpXsrfTokenExtractor,
   ) {
     this.resizeObserver = new ResizeObserver(() => this.updateMapSize());
-    this.made3D = false;
+    this.made3d = false;
   }
 
   public initMap(options: MapViewerOptionsModel, initialOptions?: { initialCenter?: [number, number]; initialZoom?: number }) {
@@ -121,7 +121,7 @@ export class OpenLayersMap implements MapViewerModel {
     const layerManager = new OpenLayersLayerManager(olMap, this.ngZone, this.httpXsrfTokenExtractor);
     layerManager.init();
     const toolManager = new OpenLayersToolManager(olMap, this.ngZone);
-    OpenLayersEventManager.initEvents(olMap, this.ngZone, this.in3D);
+    OpenLayersEventManager.initEvents(olMap, this.ngZone, this.in3d);
 
     this.map.next(olMap);
     this.layerManager.next(layerManager);
@@ -383,7 +383,7 @@ export class OpenLayersMap implements MapViewerModel {
 
   public getCesiumManager$(): Observable<CesiumManager> {
     const isCesiumManager = (item: CesiumManager | null): item is CesiumManager => item !== null;
-    return this.map3D.asObservable().pipe(filter(isCesiumManager));
+    return this.map3d.asObservable().pipe(filter(isCesiumManager));
   }
 
   public executeCesiumAction(fn: (cesiumManager: CesiumManager) => void) {
@@ -392,11 +392,11 @@ export class OpenLayersMap implements MapViewerModel {
       .subscribe(cesiumManager => fn(cesiumManager));
   }
 
-  public make3D(){
-    if (!this.made3D) {
-      this.made3D = true;
+  public make3d(){
+    if (!this.made3d) {
+      this.made3d = true;
       this.executeMapAction(olMap => {
-        this.map3D.next(new CesiumManager(olMap, this.ngZone, this.map.getValue()?.getView().getProjection()));
+        this.map3d.next(new CesiumManager(olMap, this.ngZone, this.map.getValue()?.getView().getProjection()));
       });
       this.executeCesiumAction(cesiumManager => {
         cesiumManager.init();
@@ -404,11 +404,11 @@ export class OpenLayersMap implements MapViewerModel {
     }
   }
 
-  public switch3D(){
+  public switch3d(){
     this.executeCesiumAction(cesiumManager => {
       cesiumManager.switch3d();
     });
-    this.in3D.next(!this.in3D.value);
+    this.in3d.next(!this.in3d.value);
   }
 
 }


### PR DESCRIPTION
[![HTM-1489](https://badgen.net/badge/JIRA/HTM-1489/pink?icon=jira)](https://b3partners.atlassian.net/browse/HTM-1489) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=Tailormap&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

HTM-1489: Fixes click tool always being enabled
HTM-1457: Refactored click tool to remove 3D observable for OpenLayersClickTool

[HTM-1489]: https://b3partners.atlassian.net/browse/HTM-1489?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ