### PR TITLE
HTM-1396: Fixes missing layers in print

### DIFF
--- a/projects/map/src/lib/openlayers-map/openlayers-map-image-exporter.ts
+++ b/projects/map/src/lib/openlayers-map/openlayers-map-image-exporter.ts
@@ -28,7 +28,6 @@ export class OpenLayersMapImageExporter {
     httpXsrfTokenExtractor: HttpXsrfTokenExtractor,
   ): Observable<string> {
     const viewResolution = olView.getResolution();
-
     if (!olSize || !viewResolution) {
       throw new Error('Map has no size or resolution');
     }
@@ -85,7 +84,6 @@ export class OpenLayersMapImageExporter {
     const imageExportOlMap = new OlMap({
       controls: [scaleLineControl],
       interactions: [],
-      target,
       pixelRatio: sizeRatio,
       view: new View({
         projection: olView.getProjection(),
@@ -152,12 +150,7 @@ export class OpenLayersMapImageExporter {
       }
     });
 
-    imageExportOlMap.setSize(imageExportOlSize);
-    imageExportOlMap.render();
-
-    // const imageExportExtent = imageExportOlMap.getView().calculateExtent(imageExportOlMap.getSize());
-    // console.log(`Map image export OL size set to ${imageExportOlSize[0]} x ${imageExportOlSize[1]} px, for final image size ${width} x ${height}, ` +
-    //   `pixelRatio ${sizeRatio.toFixed(3)}, view extent ${imageExportExtent.map(n => n.toFixed(3))}`);
+    imageExportOlMap.setTarget(target);
 
     return renderedMapCanvasDataURL$.asObservable();
   }


### PR DESCRIPTION
This PR addresses a rendering issue in the `OpenLayersMapImageExporter.exportMapImage$` method, where the OpenLayers map would render twice during the export process. Previously, setting the map target during initialization triggered an initial render, and a subsequent call to setSize caused a second render. This could result in the export being performed between renders, leading to missing layers in the exported image.

The fix ensures that the map target is set only after all configurations are complete, preventing multiple renders and guaranteeing that all layers are present in the exported image.