### PR TITLE
EK-48: Add IMAGE featuretype and related styling options for advanced drawing

### DIFF
--- a/projects/core/src/lib/components/drawing/drawing-style-form/drawing-style-form.component.ts
+++ b/projects/core/src/lib/components/drawing/drawing-style-form/drawing-style-form.component.ts
@@ -88,7 +88,8 @@ export class DrawingStyleFormComponent implements OnInit, OnDestroy {
   }
 
   public showPointSettings(): boolean {
-    return this.type === DrawingFeatureTypeEnum.POINT;
+    return this.type === DrawingFeatureTypeEnum.POINT
+      || this.type === DrawingFeatureTypeEnum.IMAGE;
   }
 
   public showLabelSettings(): boolean {

--- a/projects/core/src/lib/components/drawing/models/drawing-feature.model.ts
+++ b/projects/core/src/lib/components/drawing/models/drawing-feature.model.ts
@@ -23,6 +23,9 @@ export enum LabelStyleEnum {
 }
 
 export interface DrawingFeatureStyleModel {
+  // this is (must be) fully qualified url to a marker image
+  markerImage?: string;
+  description?: string;
   marker?: MarkerType;
   markerSize?: number;
   markerFillColor?: string;

--- a/projects/core/src/lib/map/components/map-drawing-buttons/map-drawing-buttons.component.ts
+++ b/projects/core/src/lib/map/components/map-drawing-buttons/map-drawing-buttons.component.ts
@@ -198,6 +198,7 @@ export class MapDrawingButtonsComponent implements OnInit, OnDestroy {
       [DrawingFeatureTypeEnum.RECTANGLE_SPECIFIED_SIZE]: 'point',
       [DrawingFeatureTypeEnum.ELLIPSE]: 'ellipse',
       [DrawingFeatureTypeEnum.STAR]: 'star',
+      [DrawingFeatureTypeEnum.IMAGE]: 'point',
     };
     return dict[type];
   }

--- a/projects/core/src/lib/map/models/drawing-feature-type.enum.ts
+++ b/projects/core/src/lib/map/models/drawing-feature-type.enum.ts
@@ -10,4 +10,5 @@ export enum DrawingFeatureTypeEnum {
   RECTANGLE_SPECIFIED_SIZE = 'RECTANGLE_SPECIFIED_SIZE',
   SQUARE = 'SQUARE',
   STAR = 'STAR',
+  IMAGE = 'IMAGE',
 }

--- a/projects/core/src/lib/map/services/drawing.service.ts
+++ b/projects/core/src/lib/map/services/drawing.service.ts
@@ -240,6 +240,7 @@ export class DrawingService {
       [DrawingFeatureTypeEnum.RECTANGLE_SPECIFIED_SIZE]: 'point',
       [DrawingFeatureTypeEnum.ELLIPSE]: 'ellipse',
       [DrawingFeatureTypeEnum.STAR]: 'star',
+      [DrawingFeatureTypeEnum.IMAGE]: 'point',
     };
     return dict[type];
   }


### PR DESCRIPTION
[![EK-48](https://badgen.net/badge/JIRA/EK-48/pink?icon=jira)](https://b3partners.atlassian.net/browse/EK-48) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=Tailormap&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

This adds a new IMAGE DrawingFeatureType and associated styling options (`markerImage` and `description`)

see also https://github.com/Tailormap/tailormap-api/pull/1270

[EK-48]: https://b3partners.atlassian.net/browse/EK-48?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ