### PR TITLE
HTM-1590: Select layer tree for application only once

### DIFF
--- a/projects/admin-core/src/lib/application/state/application.selectors.ts
+++ b/projects/admin-core/src/lib/application/state/application.selectors.ts
@@ -189,21 +189,15 @@ export const selectTerrainServiceLayerTreeForApplication = createSelector(
   },
 );
 
-export const selectTiles3DServiceLayerTreeForApplication = createSelector(
+export const selectServiceLayerTreeForApplication = createSelector(
+  selectDraftApplicationCrs,
   selectCatalog,
   selectGeoServices,
   selectGeoServiceLayers,
   selectFeatureTypes,
-  (catalog, services, layers, featureTypes): CatalogTreeModel[] => {
-    return CatalogFilterHelper.filterTreeByProtocol(catalog, services, layers, featureTypes, GeoServiceProtocolEnum.TILES3D);
-  },
-);
-
-export const selectServiceLayerTreeForApplication = createSelector(
-  selectBaseServiceLayerTreeForApplication,
-  selectTiles3DServiceLayerTreeForApplication,
-  (layers2D, tiles3dLayers) => {
-    return layers2D.concat(tiles3dLayers);
+  selectApplicationCatalogFilterTerm,
+  (draftApplicationCrs, catalog, services, layers, featureTypes, filterTerm): CatalogTreeModel[] => {
+    return CatalogFilterHelper.filterTreeByCrs(catalog, services, layers, featureTypes, draftApplicationCrs, filterTerm, true);
   },
 );
 

--- a/projects/admin-core/src/lib/catalog/helpers/catalog-filter.helper.ts
+++ b/projects/admin-core/src/lib/catalog/helpers/catalog-filter.helper.ts
@@ -49,6 +49,7 @@ export class CatalogFilterHelper {
     featureTypes: ExtendedFeatureTypeModel[],
     crs: string | undefined,
     filterTerm: string | undefined,
+    include3dTiles: boolean = false,
   ) {
     if (!crs) {
       return CatalogTreeHelper.catalogToTree(catalogNodes, services, serviceLayers, [], [], featureTypes);
@@ -56,7 +57,7 @@ export class CatalogFilterHelper {
     const allLayersMap = new Map(serviceLayers.map(l => [ l.id, l ]));
     const filteredItems = CatalogFilterHelper.getFilteredItems(catalogNodes, services, serviceLayers, [], featureTypes, item => {
       if (ExtendedCatalogModelHelper.isGeoServiceLayerModel(item)) {
-        if (item.crs?.includes(crs)) {
+        if (item.crs?.includes(crs) || (include3dTiles && item.protocol === GeoServiceProtocolEnum.TILES3D)) {
           return true;
         }
         let parent = item.parentId ? allLayersMap.get(item.parentId) : null;


### PR DESCRIPTION
[![HTM-1590](https://badgen.net/badge/JIRA/HTM-1590/pink?icon=jira)](https://b3partners.atlassian.net/browse/HTM-1590) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=Tailormap&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Include 3d tiles services in the selection of the layer tree for the application, instead of selecting a tree twice and concatenating, which caused a bug because the same level nodes where in the displayed tree twice

[HTM-1590]: https://b3partners.atlassian.net/browse/HTM-1590?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ