### PR TITLE
Fix repeatedly scrolling to the same feature 

### DIFF
--- a/projects/core/src/lib/components/drawing/drawing-objects-list/drawing-objects-list.component.ts
+++ b/projects/core/src/lib/components/drawing/drawing-objects-list/drawing-objects-list.component.ts
@@ -71,10 +71,13 @@ export class DrawingObjectsListComponent {
     this.editingDescriptionForFeatureFid = null;
   }
 
+  private srcolledToFeature: string | null = null;
+
   private scrollToSelectedFeature() {
-    if (!this.isExpanded() || !this.selectedFeature || !this.elRef || !this.elRef.nativeElement) {
+    if (!this.isExpanded() || !this.selectedFeature || !this.elRef || !this.elRef.nativeElement || this.srcolledToFeature === this.selectedFeature) {
       return;
     }
+    this.srcolledToFeature = this.selectedFeature;
     this.elRef.nativeElement.querySelector(`[data-feature-fid="${this.selectedFeature}"]`)?.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
   }
 


### PR DESCRIPTION
afterRender() fires also when moving mouse from side panel to map, should only scroll to the selected object when first selected.