### PR TITLE
EO-564: Move preset filter tool option to bottom

### DIFF
--- a/projects/admin-core/assets/locale/messages.admin-core.de.xlf
+++ b/projects/admin-core/assets/locale/messages.admin-core.de.xlf
@@ -282,6 +282,10 @@
         <source>Checkbox</source>
         <target>Kontrollkästchen</target>
       </trans-unit>
+      <trans-unit id="admin-core.application.filters.choose-tool" datatype="html">
+        <source>Choose filter tool</source>
+        <target>Filterwerkzeug auswählen</target>
+      </trans-unit>
       <trans-unit id="admin-core.application.filters.create-filter" datatype="html">
         <source>Create filter</source>
         <target>Filter erstellen</target>
@@ -421,10 +425,6 @@
       <trans-unit id="admin-core.application.filters.too-many-values" datatype="html">
         <source> Too many unique values, showing only the first <x id="PH" equiv-text="ApplicationEditFilterFormComponent.MAX_CHECKBOX_VALUES"/>.</source>
         <target>Zu viele eindeutige Werte, es werden nur die ersten <x id="PH" equiv-text="ApplicationEditFilterFormComponent.MAX_CHECKBOX_VALUES"/> angezeigt.</target>
-      </trans-unit>
-      <trans-unit id="admin-core.application.filters.tool" datatype="html">
-        <source>Tool</source>
-        <target>Werkzeug</target>
       </trans-unit>
       <trans-unit id="admin-core.application.folder-name" datatype="html">
         <source>Folder name</source>
@@ -1474,13 +1474,13 @@
         <source>Feature info</source>
         <target>Feature-Informationen</target>
       </trans-unit>
-      <trans-unit id="admin-core.components.geolocation-no-timeout" datatype="html">
-        <source>Show location on the map until the button is toggled off.</source>
-        <target>Standort auf der Karte anzeigen, bis die Schaltfläche deaktiviert wird.</target>
-      </trans-unit>
       <trans-unit id="admin-core.components.feature-info.show-edit-button" datatype="html">
         <source>Show button to edit the feature</source>
         <target>Schaltfläche zum Bearbeiten des Objekts anzeigen</target>
+      </trans-unit>
+      <trans-unit id="admin-core.components.geolocation-no-timeout" datatype="html">
+        <source>Show location on the map until the button is toggled off.</source>
+        <target>Standort auf der Karte anzeigen, bis die Schaltfläche deaktiviert wird.</target>
       </trans-unit>
       <trans-unit id="admin-core.components.header-add-menu-item" datatype="html">
         <source>Add Menu Item</source>

--- a/projects/admin-core/assets/locale/messages.admin-core.en.xlf
+++ b/projects/admin-core/assets/locale/messages.admin-core.en.xlf
@@ -212,6 +212,9 @@
       <trans-unit id="admin-core.application.filters.checkbox" datatype="html">
         <source>Checkbox</source>
       </trans-unit>
+      <trans-unit id="admin-core.application.filters.choose-tool" datatype="html">
+        <source>Choose filter tool</source>
+      </trans-unit>
       <trans-unit id="admin-core.application.filters.create-filter" datatype="html">
         <source>Create filter</source>
       </trans-unit>
@@ -316,9 +319,6 @@
       </trans-unit>
       <trans-unit id="admin-core.application.filters.too-many-values" datatype="html">
         <source> Too many unique values, showing only the first <x id="PH" equiv-text="ApplicationEditFilterFormComponent.MAX_CHECKBOX_VALUES"/>.</source>
-      </trans-unit>
-      <trans-unit id="admin-core.application.filters.tool" datatype="html">
-        <source>Tool</source>
       </trans-unit>
       <trans-unit id="admin-core.application.folder-name" datatype="html">
         <source>Folder name</source>
@@ -1085,11 +1085,11 @@
       <trans-unit id="admin-core.components.feature-info-title" datatype="html">
         <source>Feature info</source>
       </trans-unit>
-      <trans-unit id="admin-core.components.geolocation-no-timeout" datatype="html">
-        <source>Show location on the map until the button is toggled off.</source>
-      </trans-unit>
       <trans-unit id="admin-core.components.feature-info.show-edit-button" datatype="html">
         <source>Show button to edit the feature</source>
+      </trans-unit>
+      <trans-unit id="admin-core.components.geolocation-no-timeout" datatype="html">
+        <source>Show location on the map until the button is toggled off.</source>
       </trans-unit>
       <trans-unit id="admin-core.components.header-add-menu-item" datatype="html">
         <source>Add Menu Item</source>

--- a/projects/admin-core/assets/locale/messages.admin-core.nl.xlf
+++ b/projects/admin-core/assets/locale/messages.admin-core.nl.xlf
@@ -281,6 +281,10 @@
         <source>Checkbox</source>
         <target>Vinkvakjes</target>
       </trans-unit>
+      <trans-unit id="admin-core.application.filters.choose-tool" datatype="html">
+        <source>Choose filter tool</source>
+        <target>Kies filter gereedschap</target>
+      </trans-unit>
       <trans-unit id="admin-core.application.filters.create-filter" datatype="html">
         <source>Create filter</source>
         <target>Filter aanmaken</target>
@@ -420,10 +424,6 @@
       <trans-unit id="admin-core.application.filters.too-many-values" datatype="html">
         <source> Too many unique values, showing only the first <x id="PH" equiv-text="ApplicationEditFilterFormComponent.MAX_CHECKBOX_VALUES"/>.</source>
         <target>Te veel unieke waardes, alleen de eerste <x id="PH" equiv-text="ApplicationEditFilterFormComponent.MAX_CHECKBOX_VALUES"/> worden getoond.</target>
-      </trans-unit>
-      <trans-unit id="admin-core.application.filters.tool" datatype="html">
-        <source>Tool</source>
-        <target>Gereedschap</target>
       </trans-unit>
       <trans-unit id="admin-core.application.folder-name" datatype="html">
         <source>Folder name</source>
@@ -1473,13 +1473,13 @@
         <source>Feature info</source>
         <target>Objectinformatie</target>
       </trans-unit>
-      <trans-unit id="admin-core.components.geolocation-no-timeout" datatype="html">
-        <source>Show location on the map until the button is toggled off.</source>
-        <target>Toon locatie op de kaart totdat de knop opnieuw wordt uitgeschakeld.</target>
-      </trans-unit>
       <trans-unit id="admin-core.components.feature-info.show-edit-button" datatype="html">
         <source>Show button to edit the feature</source>
         <target>Toon knop om het object te bewerken</target>
+      </trans-unit>
+      <trans-unit id="admin-core.components.geolocation-no-timeout" datatype="html">
+        <source>Show location on the map until the button is toggled off.</source>
+        <target>Toon locatie op de kaart totdat de knop opnieuw wordt uitgeschakeld.</target>
       </trans-unit>
       <trans-unit id="admin-core.components.header-add-menu-item" datatype="html">
         <source>Add Menu Item</source>

--- a/projects/admin-core/src/lib/application/application-edit-filters/filters/application-edit-filter-form/application-edit-filter-form.component.html
+++ b/projects/admin-core/src/lib/application/application-edit-filters/filters/application-edit-filter-form/application-edit-filter-form.component.html
@@ -2,8 +2,12 @@
   @if (newFilter) {
     <div class="filter-tool">
       <mat-form-field appearance="outline">
-        <mat-label i18n="@@admin-core.application.filters.tool">Tool</mat-label>
-        <mat-select formControlName="tool" placeholder="Tool" (selectionChange)="resetFormOnToolChange()">
+        <mat-label i18n="@@admin-core.application.filters.choose-tool">Choose filter tool</mat-label>
+        <mat-select
+          formControlName="tool"
+          placeholder="Choose filter tool"
+          i18n-placeholder="@@admin-core.application.filters.choose-tool"
+          (selectionChange)="resetFormOnToolChange()">
           @for (tool of filterToolOptions; track tool) {
             <mat-option [value]="tool.value">{{ tool.label }}</mat-option>
           }

--- a/projects/admin-core/src/lib/application/application-edit-filters/filters/application-edit-filter-form/application-edit-filter-form.component.ts
+++ b/projects/admin-core/src/lib/application/application-edit-filters/filters/application-edit-filter-form/application-edit-filter-form.component.ts
@@ -35,9 +35,6 @@ export class ApplicationEditFilterFormComponent implements OnInit {
   };
 
   public filterToolOptions = [{
-    label: $localize`:@@admin-core.application.filters.preset:Preset`,
-    value: FilterToolEnum.PRESET_STATIC,
-  }, {
     label: $localize`:@@admin-core.application.filters.checkbox:Checkbox`,
     value: FilterToolEnum.CHECKBOX,
   }, {
@@ -52,6 +49,9 @@ export class ApplicationEditFilterFormComponent implements OnInit {
   }, {
     label: $localize`:@@admin-core.application.filters.dropdown-list:Drop-down list`,
     value: FilterToolEnum.DROPDOWN_LIST,
+  }, {
+    label: $localize`:@@admin-core.application.filters.preset:Preset`,
+    value: FilterToolEnum.PRESET_STATIC,
   }];
 
   private static readonly MAX_CHECKBOX_VALUES = 50;
@@ -85,7 +85,7 @@ export class ApplicationEditFilterFormComponent implements OnInit {
 
   public filterForm = new FormGroup({
     id: new FormControl(''),
-    tool: new FormControl<FilterToolEnum>(FilterToolEnum.PRESET_STATIC),
+    tool: new FormControl<FilterToolEnum | null>(null),
     attribute: new FormControl(''),
     attributeType: new FormControl<AttributeType | null>(null),
     condition: new FormControl<FilterConditionEnum | null>(null),
@@ -185,6 +185,7 @@ export class ApplicationEditFilterFormComponent implements OnInit {
       && formValues.attributeType !== null
       && formValues.condition !== null
       && validFilterValues
+      && formValues.tool !== null
       && this.filterForm.dirty;
   }
 


### PR DESCRIPTION
[![EO-564](https://badgen.net/badge/JIRA/EO-564/pink?icon=jira)](https://b3partners.atlassian.net/browse/EO-564) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=Tailormap&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Move preset filter tool option to bottom and have no tool initially selected

[EO-564]: https://b3partners.atlassian.net/browse/EO-564?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ