### PR TITLE
Fix viewer components config layout

### DIFF
--- a/projects/admin-core/src/lib/application/application-edit-components/application-edit-components.component.css
+++ b/projects/admin-core/src/lib/application/application-edit-components/application-edit-components.component.css
@@ -1,7 +1,15 @@
-.components {
+.components-config-page {
+  height: 100%;
   display: flex;
 }
 
+.components-list {
+  height: 100%;
+  overflow-y: auto;
+}
+
 .component-configuration {
-  flex: 1;
+  height: 100%;
+  overflow-y: auto;
+  flex-grow: 1;
 }

--- a/projects/admin-core/src/lib/application/application-edit-components/application-edit-components.component.html
+++ b/projects/admin-core/src/lib/application/application-edit-components/application-edit-components.component.html
@@ -1,6 +1,4 @@
 <div class="components-config-page">
-
-  <div class="components">
     <div class="components-list">
       <strong i18n="@@admin-core.application.list-of-components">List of available components</strong>
       <tm-admin-components-list (selectComponent)="setSelectedComponent($event)"></tm-admin-components-list>
@@ -8,6 +6,4 @@
     <div class="component-configuration">
       <tm-admin-component-config-renderer [selectedComponent]="selectedComponent$ | async"></tm-admin-component-config-renderer>
     </div>
-  </div>
-
 </div>

--- a/projects/admin-core/src/lib/application/components/base-component-config/base-component-config.component.css
+++ b/projects/admin-core/src/lib/application/components/base-component-config/base-component-config.component.css
@@ -1,5 +1,8 @@
+.all {
+  margin-left: 16px;
+}
+
 .form ::ng-deep .row mat-form-field {
-  margin-left: 8px;
   max-width: 600px;
 }
 

--- a/projects/admin-core/src/lib/application/components/base-component-config/base-component-config.component.html
+++ b/projects/admin-core/src/lib/application/components/base-component-config/base-component-config.component.html
@@ -1,4 +1,4 @@
-<div>
+<div class="all">
   <strong>{{ label }}</strong><br />
   <div class="form" [formGroup]="formGroup">
     <div>


### PR DESCRIPTION
The list of components now scrolls independently of the component config page.