### PR TITLE
Improve attribute filter service and state

### DIFF
--- a/projects/api/src/lib/models/attribute-filter.model.ts
+++ b/projects/api/src/lib/models/attribute-filter.model.ts
@@ -13,6 +13,5 @@ export interface AttributeFilterModel extends BaseFilterModel {
   value: string[];
   type: FilterTypeEnum.ATTRIBUTE;
   editConfiguration?: EditFilterConfigurationModel;
-  attributeNotFound?: boolean;
   generatedByFilterId?: string;
 }

--- a/projects/core/src/lib/components/attribute-list/attribute-list-content/attribute-list-content.component.spec.ts
+++ b/projects/core/src/lib/components/attribute-list/attribute-list-content/attribute-list-content.component.spec.ts
@@ -48,7 +48,7 @@ describe('AttributeListContent', () => {
         provideMockStore({
           initialState: {
             ...store,
-            filter: { filterGroups: [] },
+            filter: { activeFilterGroups: [] },
           },
         }),
       ],

--- a/projects/core/src/lib/components/attribute-list/attribute-list-content/attribute-list-content.component.spec.ts
+++ b/projects/core/src/lib/components/attribute-list/attribute-list-content/attribute-list-content.component.spec.ts
@@ -48,7 +48,8 @@ describe('AttributeListContent', () => {
         provideMockStore({
           initialState: {
             ...store,
-            filter: { activeFilterGroups: [] },
+            filter: { verifiedCurrentFilterGroups: [] },
+            map: { layers: [] },
           },
         }),
       ],

--- a/projects/core/src/lib/components/filter/filter-list-item/filter-list-item.component.ts
+++ b/projects/core/src/lib/components/filter/filter-list-item/filter-list-item.component.ts
@@ -25,16 +25,7 @@ export class FilterListItemComponent {
     if (!filterGroup) {
       return;
     }
-    this.filter = {
-      ...filterGroup,
-      filters: filterGroup?.filters.filter(f => {
-        if (FilterTypeHelper.isAttributeFilter(f) && f.attributeNotFound) {
-          console.error(`Attribute '${f.attribute}' not found. Filter hidden and disabled.`);
-          return false;
-        }
-        return true;
-      }) ?? [],
-    };
+    this.filter = filterGroup;
     this.editableFilters = this.filter?.filters.filter((f): f is AttributeFilterModel =>
       FilterTypeHelper.isAttributeFilter(f) && (!!f.editConfiguration || !!f.generatedByFilterId)) ?? [];
   }

--- a/projects/core/src/lib/components/filter/state/filter-component.selectors.ts
+++ b/projects/core/src/lib/components/filter/state/filter-component.selectors.ts
@@ -1,6 +1,6 @@
 import { FilterComponentState, filterComponentStateKey } from './filter-component.state';
 import { createFeatureSelector, createSelector } from '@ngrx/store';
-import { selectFilterGroups } from '../../../filter/state/filter.selectors';
+import { selectActiveFilterGroups } from '../../../filter/state/filter.selectors';
 import { FeatureModel, FilterTypeEnum, SpatialFilterGeometry } from '@tailormap-viewer/api';
 import { FilterTypeHelper } from '../../../filter/helpers/filter-type.helper';
 import { selectVisibleLayersWithAttributes } from '../../../map/state/map.selectors';
@@ -14,7 +14,7 @@ export const selectSelectedLayersCount = createSelector(selectSelectedLayers, se
 export const hasSelectedLayers = createSelector(selectSelectedLayersCount, selectedLayersCount => selectedLayersCount > 0);
 
 export const selectSelectedFilterGroup = createSelector(
-  selectFilterGroups,
+  selectActiveFilterGroups,
   selectSelectedFilterGroupId,
   (filterGroups, selectedFilterGroupId) => {
     return filterGroups.find(group => group.id === selectedFilterGroupId);

--- a/projects/core/src/lib/filter/services/simple-attribute-filter.service.spec.ts
+++ b/projects/core/src/lib/filter/services/simple-attribute-filter.service.spec.ts
@@ -3,7 +3,7 @@ import { SimpleAttributeFilterService } from './simple-attribute-filter.service'
 import { AttributeType } from '@tailormap-viewer/api';
 import { FilterConditionEnum, AttributeFilterModel, FilterTypeEnum } from '@tailormap-viewer/api';
 import { filterStateKey } from '../state/filter.state';
-import { selectFilterGroups } from '../state/filter.selectors';
+import { selectActiveFilterGroups } from '../state/filter.selectors';
 import { Store, StoreModule } from '@ngrx/store';
 import { filterReducer } from '../state/filter.reducer';
 
@@ -43,7 +43,7 @@ describe('SimpleAttributeFilterService', () => {
   test('should create filter', (done) => {
     const { service, store } = createService();
     service.setFilter('source', '1', createFilter());
-    store.select(selectFilterGroups).subscribe(filterGroups => {
+    store.select(selectActiveFilterGroups).subscribe(filterGroups => {
       expect(filterGroups.length).toEqual(1);
       expect(filterGroups[0].id).toEqual('id-1');
       expect(filterGroups[0].filters.length).toEqual(1);
@@ -57,7 +57,7 @@ describe('SimpleAttributeFilterService', () => {
     service.setFilter('source', '1', createFilter());
     service.setFilter('source', '1', createFilter('attribute2'));
     service.setFilter('source', '1', createFilter('attribute', 'other_value'));
-    store.select(selectFilterGroups).subscribe(filterGroups => {
+    store.select(selectActiveFilterGroups).subscribe(filterGroups => {
       expect(filterGroups.length).toEqual(1);
       expect(filterGroups[0].id).toEqual('id-1');
       expect(filterGroups[0].filters.length).toEqual(2);
@@ -78,7 +78,7 @@ describe('SimpleAttributeFilterService', () => {
     service.setFilter('source', '1', createFilter());
     // now remove that filter
     service.removeFilter('source', '1', 'attribute');
-    store.select(selectFilterGroups).subscribe(filterGroups => {
+    store.select(selectActiveFilterGroups).subscribe(filterGroups => {
       expect(filterGroups.length).toEqual(0);
       done();
     });
@@ -89,7 +89,7 @@ describe('SimpleAttributeFilterService', () => {
     service.setFilter('source', '1', createFilter());
     service.setFilter('source', '1', createFilter('attribute2'));
     service.removeFilter('source', '1', 'attribute');
-    store.select(selectFilterGroups).subscribe(filterGroups => {
+    store.select(selectActiveFilterGroups).subscribe(filterGroups => {
       expect(filterGroups.length).toEqual(1);
       expect(filterGroups[0].id).toEqual('id-1');
       expect(filterGroups[0].filters.length).toEqual(1);
@@ -104,7 +104,7 @@ describe('SimpleAttributeFilterService', () => {
     service.setFilter('source', '2', createFilter());
     service.setFilter('source', '3', createFilter());
     service.removeFiltersForLayer('source', '2');
-    store.select(selectFilterGroups).subscribe(filterGroups => {
+    store.select(selectActiveFilterGroups).subscribe(filterGroups => {
       expect(filterGroups.length).toEqual(2);
       expect(filterGroups[0].layerIds).toEqual(['1']);
       expect(filterGroups[1].layerIds).toEqual(['3']);

--- a/projects/core/src/lib/filter/state/filter.actions.ts
+++ b/projects/core/src/lib/filter/state/filter.actions.ts
@@ -6,7 +6,7 @@ const filterActionsPrefix = '[Filter]';
 
 export const addAllFilterGroupsInConfig = createAction(
   `${filterActionsPrefix} Add All Filter Groups In Config`,
-  props<{ filterGroups: FilterGroupModel[] }>(),
+  props<{ filterGroups: FilterGroupModel<AttributeFilterModel>[] }>(),
 );
 
 export const addFilterGroup = createAction(
@@ -47,4 +47,9 @@ export const toggleFilterDisabled = createAction(
 export const setSingleFilterDisabled = createAction(
   `${filterActionsPrefix} Toggle Single Filter Disabled`,
   props<{ filterGroupId: string; filterId: string; disabled: boolean }>(),
+);
+
+export const addLayerIdsToFilterGroup = createAction(
+  `${filterActionsPrefix} Add Layer Ids To Filter Group`,
+  props<{ filterGroupId: string; layerIds: string[] }>(),
 );

--- a/projects/core/src/lib/filter/state/filter.actions.ts
+++ b/projects/core/src/lib/filter/state/filter.actions.ts
@@ -4,6 +4,11 @@ import { AttributeFilterModel } from '@tailormap-viewer/api';
 
 const filterActionsPrefix = '[Filter]';
 
+export const addAllFilterGroupsInConfig = createAction(
+  `${filterActionsPrefix} Add All Filter Groups In Config`,
+  props<{ filterGroups: FilterGroupModel[] }>(),
+);
+
 export const addFilterGroup = createAction(
   `${filterActionsPrefix} Add Filter Group`,
   props<{ filterGroup: FilterGroupModel }>(),

--- a/projects/core/src/lib/filter/state/filter.reducer.ts
+++ b/projects/core/src/lib/filter/state/filter.reducer.ts
@@ -19,16 +19,28 @@ const updateFilterGroup = (
   updateFn: (filterGroup: FilterGroupModel) => FilterGroupModel,
 ): FilterState => {
   const idx = state.filterGroups.findIndex(fg => fg.id === filterGroupId);
-  if (idx === -1) {
+  const idxInAllFilterGroups = state.allFilterGroupsInConfig.findIndex(fg => fg.id === filterGroupId);
+  if (idx === -1 && idxInAllFilterGroups === -1) {
     return state;
   }
-  return {
-    ...state,
-    filterGroups: [
+  const newFilterGroups = idx === -1
+    ? state.filterGroups
+    : [
       ...state.filterGroups.slice(0, idx),
       updateFn(state.filterGroups[idx]),
       ...state.filterGroups.slice(idx + 1),
-    ],
+    ];
+  const newAllFilterGroupsInConfig = idxInAllFilterGroups === -1
+    ? state.allFilterGroupsInConfig
+    : [
+      ...state.allFilterGroupsInConfig.slice(0, idxInAllFilterGroups),
+      updateFn(state.allFilterGroupsInConfig[idxInAllFilterGroups]),
+      ...state.allFilterGroupsInConfig.slice(idxInAllFilterGroups + 1),
+    ];
+  return {
+    ...state,
+    filterGroups: newFilterGroups,
+    allFilterGroupsInConfig: newAllFilterGroupsInConfig,
   };
 };
 

--- a/projects/core/src/lib/filter/state/filter.reducer.ts
+++ b/projects/core/src/lib/filter/state/filter.reducer.ts
@@ -3,6 +3,16 @@ import { Action, createReducer, on } from '@ngrx/store';
 import { FilterState, initialFilterState } from './filter.state';
 import { FilterGroupModel } from '@tailormap-viewer/api';
 
+const onAddAllFilterGroupsInConfig = (
+  state: FilterState,
+  payload: ReturnType<typeof FilterActions.addAllFilterGroupsInConfig>,
+): FilterState => {
+  return {
+    ...state,
+    allFilterGroupsInConfig: payload.filterGroups,
+  };
+};
+
 const updateFilterGroup = (
   state: FilterState,
   filterGroupId: string,
@@ -148,6 +158,7 @@ const onSetSingleFilterDisabled = (
 
 const filterReducerImpl = createReducer<FilterState>(
   initialFilterState,
+  on(FilterActions.addAllFilterGroupsInConfig, onAddAllFilterGroupsInConfig),
   on(FilterActions.addFilterGroup, onAddFilterGroup),
   on(FilterActions.removeFilterGroup, onRemoveFilterGroup),
   on(FilterActions.updateFilterGroup, onUpdateFilterGroup),

--- a/projects/core/src/lib/filter/state/filter.reducer.ts
+++ b/projects/core/src/lib/filter/state/filter.reducer.ts
@@ -18,17 +18,17 @@ const updateFilterGroup = (
   filterGroupId: string,
   updateFn: (filterGroup: FilterGroupModel) => FilterGroupModel,
 ): FilterState => {
-  const idx = state.filterGroups.findIndex(fg => fg.id === filterGroupId);
+  const idx = state.activeFilterGroups.findIndex(fg => fg.id === filterGroupId);
   const idxInAllFilterGroups = state.allFilterGroupsInConfig.findIndex(fg => fg.id === filterGroupId);
   if (idx === -1 && idxInAllFilterGroups === -1) {
     return state;
   }
   const newFilterGroups = idx === -1
-    ? state.filterGroups
+    ? state.activeFilterGroups
     : [
-      ...state.filterGroups.slice(0, idx),
-      updateFn(state.filterGroups[idx]),
-      ...state.filterGroups.slice(idx + 1),
+      ...state.activeFilterGroups.slice(0, idx),
+      updateFn(state.activeFilterGroups[idx]),
+      ...state.activeFilterGroups.slice(idx + 1),
     ];
   const newAllFilterGroupsInConfig = idxInAllFilterGroups === -1
     ? state.allFilterGroupsInConfig
@@ -39,7 +39,7 @@ const updateFilterGroup = (
     ];
   return {
     ...state,
-    filterGroups: newFilterGroups,
+    activeFilterGroups: newFilterGroups,
     allFilterGroupsInConfig: newAllFilterGroupsInConfig,
   };
 };
@@ -48,13 +48,13 @@ const onAddFilterGroup = (
   state: FilterState,
   payload: ReturnType<typeof FilterActions.addFilterGroup>,
 ): FilterState => {
-  if (state.filterGroups.find(fg => fg.id === payload.filterGroup.id)) {
+  if (state.activeFilterGroups.find(fg => fg.id === payload.filterGroup.id)) {
     return state;
   }
   return {
     ...state,
-    filterGroups: [
-      ...state.filterGroups,
+    activeFilterGroups: [
+      ...state.activeFilterGroups,
       payload.filterGroup,
     ],
   };
@@ -64,15 +64,15 @@ const onRemoveFilterGroup = (
   state: FilterState,
   payload: ReturnType<typeof FilterActions.removeFilterGroup>,
 ): FilterState => {
-  const idx = state.filterGroups.findIndex(fg => fg.id === payload.filterGroupId);
+  const idx = state.activeFilterGroups.findIndex(fg => fg.id === payload.filterGroupId);
   if (idx === -1) {
     return state;
   }
   return {
     ...state,
-    filterGroups: [
-      ...state.filterGroups.slice(0, idx),
-      ...state.filterGroups.slice(idx + 1),
+    activeFilterGroups: [
+      ...state.activeFilterGroups.slice(0, idx),
+      ...state.activeFilterGroups.slice(idx + 1),
     ],
   };
 };

--- a/projects/core/src/lib/filter/state/filter.selectors.ts
+++ b/projects/core/src/lib/filter/state/filter.selectors.ts
@@ -25,7 +25,7 @@ export const selectActiveFilterGroups = createSelector(
       .filter(group => group.layerIds.some(layerId => visibleLayerIds.includes(layerId)))
       .map(group => ({
         ...group,
-        layersIds: group.layerIds.filter(layerId => visibleLayerIds.includes(layerId)),
+        layerIds: group.layerIds.filter(layerId => visibleLayerIds.includes(layerId)),
       }));
   },
 );

--- a/projects/core/src/lib/filter/state/filter.selectors.ts
+++ b/projects/core/src/lib/filter/state/filter.selectors.ts
@@ -12,6 +12,8 @@ import { SpatialFilterModel } from '@tailormap-viewer/api';
 
 const selectFilterState = createFeatureSelector<FilterState>(filterStateKey);
 
+export const selectAllFilterGroupsInConfig = createSelector(selectFilterState, state => state.allFilterGroupsInConfig);
+
 export const selectFilterGroups = createSelector(selectFilterState, state => state.filterGroups);
 
 export const selectFilterGroup = (source: string, layerId: string) => createSelector(

--- a/projects/core/src/lib/filter/state/filter.selectors.ts
+++ b/projects/core/src/lib/filter/state/filter.selectors.ts
@@ -14,7 +14,7 @@ const selectFilterState = createFeatureSelector<FilterState>(filterStateKey);
 
 export const selectAllFilterGroupsInConfig = createSelector(selectFilterState, state => state.allFilterGroupsInConfig);
 
-export const selectFilterGroups = createSelector(selectFilterState, state => state.filterGroups);
+export const selectFilterGroups = createSelector(selectFilterState, state => state.activeFilterGroups);
 
 export const selectFilterGroup = (source: string, layerId: string) => createSelector(
   selectFilterGroups,

--- a/projects/core/src/lib/filter/state/filter.state.ts
+++ b/projects/core/src/lib/filter/state/filter.state.ts
@@ -3,7 +3,10 @@ import { FilterGroupModel } from '@tailormap-viewer/api';
 export const filterStateKey = 'filter';
 
 export interface FilterState {
+  // All filter groups that are defined in the application config
   allFilterGroupsInConfig: FilterGroupModel[];
+
+  // Validated filter groups for visible layers
   filterGroups: FilterGroupModel[];
 }
 

--- a/projects/core/src/lib/filter/state/filter.state.ts
+++ b/projects/core/src/lib/filter/state/filter.state.ts
@@ -7,10 +7,10 @@ export interface FilterState {
   allFilterGroupsInConfig: FilterGroupModel[];
 
   // Validated filter groups for visible layers
-  filterGroups: FilterGroupModel[];
+  activeFilterGroups: FilterGroupModel[];
 }
 
 export const initialFilterState: FilterState = {
   allFilterGroupsInConfig: [],
-  filterGroups: [],
+  activeFilterGroups: [],
 };

--- a/projects/core/src/lib/filter/state/filter.state.ts
+++ b/projects/core/src/lib/filter/state/filter.state.ts
@@ -3,9 +3,11 @@ import { FilterGroupModel } from '@tailormap-viewer/api';
 export const filterStateKey = 'filter';
 
 export interface FilterState {
+  allFilterGroupsInConfig: FilterGroupModel[];
   filterGroups: FilterGroupModel[];
 }
 
 export const initialFilterState: FilterState = {
+  allFilterGroupsInConfig: [],
   filterGroups: [],
 };

--- a/projects/core/src/lib/filter/state/filter.state.ts
+++ b/projects/core/src/lib/filter/state/filter.state.ts
@@ -1,16 +1,16 @@
-import { FilterGroupModel } from '@tailormap-viewer/api';
+import { AttributeFilterModel, FilterGroupModel } from '@tailormap-viewer/api';
 
 export const filterStateKey = 'filter';
 
 export interface FilterState {
   // All filter groups that are defined in the application config
-  allFilterGroupsInConfig: FilterGroupModel[];
+  configuredFilterGroups: FilterGroupModel<AttributeFilterModel>[];
 
-  // Validated filter groups for visible layers
-  activeFilterGroups: FilterGroupModel[];
+  // Validated filter groups in their current state, i.e. with changes from users
+  verifiedCurrentFilterGroups: FilterGroupModel[];
 }
 
 export const initialFilterState: FilterState = {
-  allFilterGroupsInConfig: [],
-  activeFilterGroups: [],
+  configuredFilterGroups: [],
+  verifiedCurrentFilterGroups: [],
 };

--- a/projects/core/src/lib/services/attribute-filter.service.ts
+++ b/projects/core/src/lib/services/attribute-filter.service.ts
@@ -18,7 +18,6 @@ export class AttributeFilterService {
   private describeAppLayerService = inject(DescribeAppLayerService);
 
   public constructor() {
-    console.debug("AttributeFilterService initialized");
     this.store$.select(selectViewerLoadingState).pipe(
       first(status => status === LoadingStateEnum.LOADED),
     ).subscribe(() => {

--- a/projects/core/src/lib/services/attribute-filter.service.ts
+++ b/projects/core/src/lib/services/attribute-filter.service.ts
@@ -42,18 +42,18 @@ export class AttributeFilterService {
           const layerIds = Array.from(
             new Set(
               filterGroups.flatMap(group =>
-                group.layerIds.filter(id => visibleLayerIds.includes(id))
-              )
-            )
+                group.layerIds.filter(id => visibleLayerIds.includes(id)),
+              ),
+            ),
           );
           // get attribute names for all visible layers in filterGroups
           return forkJoin(
             layerIds.map(layerId =>
               this.getAttributeNamesForLayer$(layerId).pipe(
                 take(1),
-                map((attributeNames): [string, string[]] => [layerId, attributeNames]),
-              )
-            )
+                map((attributeNames): [string, string[]] => [ layerId, attributeNames ]),
+              ),
+            ),
           ).pipe(
             map(layerIdsWithListOfAttributeNames => new Map(layerIdsWithListOfAttributeNames)),
             // use map of layers with attribute names to filter out invisible layers and disable filters for missing attributes
@@ -65,7 +65,7 @@ export class AttributeFilterService {
                   layerIds: validLayerIds,
                   filters: group.filters.map((filter): AttributeFilterModel => {
                     const attributeExists = validLayerIds.every(layerId =>
-                      layerAttributesMap.get(layerId)?.includes(filter.attribute)
+                      layerAttributesMap.get(layerId)?.includes(filter.attribute),
                     );
                     return {
                       ...filter,
@@ -74,7 +74,7 @@ export class AttributeFilterService {
                     };
                   }),
                 };
-              })
+              }),
             ),
           );
         }),

--- a/projects/core/src/lib/services/attribute-filter.service.ts
+++ b/projects/core/src/lib/services/attribute-filter.service.ts
@@ -75,7 +75,7 @@ export class AttributeFilterService {
           );
         }),
         withLatestFrom(this.store$.select(selectFilterGroups)),
-      ).subscribe(([groups, visibleGroups]) => {
+      ).subscribe(([ groups, visibleGroups ]) => {
         const visibleGroupIds = visibleGroups.map(g => g.id);
         for (const group of groups) {
           if (visibleGroupIds.includes(group.id)) {

--- a/projects/core/src/lib/state/core.effects.ts
+++ b/projects/core/src/lib/state/core.effects.ts
@@ -44,7 +44,7 @@ export class CoreEffects {
       ofType(CoreActions.loadViewerSuccess),
       map(action => action.viewer.filterGroups || []),
       map(groups => this.attributeFilterService.separateSubstringFiltersInCheckboxFilters(groups)),
-      tap(groups => this.attributeFilterService.disableFiltersForMissingAttributes$(groups)),
+      tap(groups => this.attributeFilterService.disableFiltersForMissingAttributes(groups)),
       map(filterGroups => FilterActions.addAllFilterGroupsInConfig({ filterGroups })),
     );
   });

--- a/projects/core/src/lib/state/core.effects.ts
+++ b/projects/core/src/lib/state/core.effects.ts
@@ -44,7 +44,6 @@ export class CoreEffects {
       ofType(CoreActions.loadViewerSuccess),
       map(action => action.viewer.filterGroups || []),
       map(groups => this.attributeFilterService.separateSubstringFiltersInCheckboxFilters(groups)),
-      tap(groups => this.attributeFilterService.disableFiltersForMissingAttributes(groups)),
       map(filterGroups => FilterActions.addAllFilterGroupsInConfig({ filterGroups })),
     );
   });

--- a/projects/core/src/lib/state/core.effects.ts
+++ b/projects/core/src/lib/state/core.effects.ts
@@ -2,7 +2,7 @@ import { inject, Injectable } from '@angular/core';
 import { Actions, createEffect, ofType } from '@ngrx/effects';
 import * as CoreActions from './core.actions';
 import * as FilterActions from '../filter/state/filter.actions';
-import { concatMap, map, tap, filter, switchMap } from 'rxjs';
+import { concatMap, map, tap, filter } from 'rxjs';
 import { LoadViewerService } from '../services/load-viewer.service';
 import { Location } from '@angular/common';
 import { Router } from '@angular/router';
@@ -43,10 +43,9 @@ export class CoreEffects {
     return this.actions$.pipe(
       ofType(CoreActions.loadViewerSuccess),
       map(action => action.viewer.filterGroups || []),
-      switchMap(groups => this.attributeFilterService.disableFiltersForMissingAttributes$(groups)),
       map(groups => this.attributeFilterService.separateSubstringFiltersInCheckboxFilters(groups)),
-      concatMap(filterGroups => filterGroups.map(
-          filterGroup => FilterActions.addFilterGroup({ filterGroup }))),
+      tap(groups => this.attributeFilterService.disableFiltersForMissingAttributes$(groups)),
+      map(filterGroups => FilterActions.addAllFilterGroupsInConfig({ filterGroups })),
     );
   });
 


### PR DESCRIPTION
- In the filter state the active filter groups with visible layers and validated filters are kept in a separate list next to the list of all filter groups in the viewer configuration.
- When the visible layers change the filter groups for the visible layers are validated and the list of active groups is updated if needed.
- getDescribeAppLayer$ is called only once per layer if the layer is in multiple groups.