### PR TITLE
HTM-1665: Fix component initial config not used

### DIFF
--- a/projects/admin-api/package.json
+++ b/projects/admin-api/package.json
@@ -8,7 +8,7 @@
     "@angular/common": "^20.1.4",
     "@angular/core": "^20.1.4",
     "rxjs": "^7.8.2",
-    "@tailormap-viewer/api": "^12.1.3"
+    "@tailormap-viewer/api": "^12.1.4-rc.1"
   },
   "dependencies": {
     "tslib": "^2.8.1"

--- a/projects/admin-api/package.json
+++ b/projects/admin-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tailormap-admin/admin-api",
-  "version": "12.1.3",
+  "version": "12.1.4-rc.1",
   "publishConfig": {
     "registry": "https://repo.b3p.nl/nexus/repository/npm-public"
   },

--- a/projects/admin-core/package.json
+++ b/projects/admin-core/package.json
@@ -19,7 +19,7 @@
     "@ngrx/store": "^20.0.0",
     "@ngrx/store-devtools": "^20.0.0",
     "@tailormap-admin/admin-api": "^12.1.3",
-    "@tailormap-viewer/api": "^12.1.3",
+    "@tailormap-viewer/api": "^12.1.4-rc.1",
     "@tailormap-viewer/shared": "^12.1.3",
     "nanoid": "^5.1.4",
     "rxjs": "^7.8.2"

--- a/projects/admin-core/package.json
+++ b/projects/admin-core/package.json
@@ -20,7 +20,7 @@
     "@ngrx/store-devtools": "^20.0.0",
     "@tailormap-admin/admin-api": "^12.1.3",
     "@tailormap-viewer/api": "^12.1.4-rc.1",
-    "@tailormap-viewer/shared": "^12.1.3",
+    "@tailormap-viewer/shared": "^12.1.4-rc.1",
     "nanoid": "^5.1.4",
     "rxjs": "^7.8.2"
   },

--- a/projects/admin-core/package.json
+++ b/projects/admin-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tailormap-admin/admin-core",
-  "version": "12.1.3",
+  "version": "12.1.4-rc.1",
   "publishConfig": {
     "registry": "https://repo.b3p.nl/nexus/repository/npm-public"
   },

--- a/projects/admin-core/package.json
+++ b/projects/admin-core/package.json
@@ -18,7 +18,7 @@
     "@ngrx/operators": "^20.0.0",
     "@ngrx/store": "^20.0.0",
     "@ngrx/store-devtools": "^20.0.0",
-    "@tailormap-admin/admin-api": "^12.1.3",
+    "@tailormap-admin/admin-api": "^12.1.4-rc.1",
     "@tailormap-viewer/api": "^12.1.4-rc.1",
     "@tailormap-viewer/shared": "^12.1.4-rc.1",
     "nanoid": "^5.1.4",

--- a/projects/api/package.json
+++ b/projects/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tailormap-viewer/api",
-  "version": "12.1.3",
+  "version": "12.1.4-rc.1",
   "publishConfig": {
     "registry": "https://repo.b3p.nl/nexus/repository/npm-public"
   },

--- a/projects/core/package.json
+++ b/projects/core/package.json
@@ -24,7 +24,7 @@
     "@stardazed/zlib": "^1.0.1",
     "@tailormap-viewer/shared": "^12.1.3",
     "@tailormap-viewer/map": "^12.1.3",
-    "@tailormap-viewer/api": "^12.1.3",
+    "@tailormap-viewer/api": "^12.1.4-rc.1",
     "jspdf": "^3.0.2",
     "luxon": "^3.5.0",
     "nanoid": "^5.1.4",

--- a/projects/core/package.json
+++ b/projects/core/package.json
@@ -23,7 +23,7 @@
     "@sentry/browser": "^10.1.0",
     "@stardazed/zlib": "^1.0.1",
     "@tailormap-viewer/shared": "^12.1.4-rc.1",
-    "@tailormap-viewer/map": "^12.1.3",
+    "@tailormap-viewer/map": "^12.1.4-rc.1",
     "@tailormap-viewer/api": "^12.1.4-rc.1",
     "jspdf": "^3.0.2",
     "luxon": "^3.5.0",

--- a/projects/core/package.json
+++ b/projects/core/package.json
@@ -22,7 +22,7 @@
     "@sentry/angular": "^10.1.0",
     "@sentry/browser": "^10.1.0",
     "@stardazed/zlib": "^1.0.1",
-    "@tailormap-viewer/shared": "^12.1.3",
+    "@tailormap-viewer/shared": "^12.1.4-rc.1",
     "@tailormap-viewer/map": "^12.1.3",
     "@tailormap-viewer/api": "^12.1.4-rc.1",
     "jspdf": "^3.0.2",

--- a/projects/core/package.json
+++ b/projects/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tailormap-viewer/core",
-  "version": "12.1.3",
+  "version": "12.1.4-rc.1",
   "publishConfig": {
     "registry": "https://repo.b3p.nl/nexus/repository/npm-public"
   },

--- a/projects/core/src/lib/shared/helpers/component-config.helper.ts
+++ b/projects/core/src/lib/shared/helpers/component-config.helper.ts
@@ -20,7 +20,7 @@ export class ComponentConfigHelper {
   ) {
     return store$.select(selectViewerLoadingState)
       .pipe(
-        filter(loadState => loadState === LoadingStateEnum.LOADED || loadState === LoadingStateEnum.FAILED),
+        filter(loadState => loadState === LoadingStateEnum.LOADED),
         take(1),
         switchMap(() => store$.select(selectComponentsConfigForType<ConfigType>(type)).pipe(take(1))),
       )

--- a/projects/map/package.json
+++ b/projects/map/package.json
@@ -16,7 +16,7 @@
     "jsts": "^2.12.1",
     "rxjs": "^7.8.2",
     "@tailormap-viewer/shared": "^12.1.3",
-    "@tailormap-viewer/api": "^12.1.3"
+    "@tailormap-viewer/api": "^12.1.4-rc.1"
   },
   "dependencies": {
     "tslib": "^2.8.1"

--- a/projects/map/package.json
+++ b/projects/map/package.json
@@ -15,7 +15,7 @@
     "html2canvas": "^1.4.1",
     "jsts": "^2.12.1",
     "rxjs": "^7.8.2",
-    "@tailormap-viewer/shared": "^12.1.3",
+    "@tailormap-viewer/shared": "^12.1.4-rc.1",
     "@tailormap-viewer/api": "^12.1.4-rc.1"
   },
   "dependencies": {

--- a/projects/map/package.json
+++ b/projects/map/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tailormap-viewer/map",
-  "version": "12.1.3",
+  "version": "12.1.4-rc.1",
   "publishConfig": {
     "registry": "https://repo.b3p.nl/nexus/repository/npm-public"
   },

--- a/projects/shared/package.json
+++ b/projects/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tailormap-viewer/shared",
-  "version": "12.1.3",
+  "version": "12.1.4-rc.1",
   "publishConfig": {
     "registry": "https://repo.b3p.nl/nexus/repository/npm-public"
   },


### PR DESCRIPTION
`ComponentConfigHelper.useInitialConfigForComponent()` does not call the callback after logging in succesfully after viewer loading first failed due to not being logged in. Only occurs when logging in without page reload using a Tailormap account, not OIDC.