### PR TITLE
HTM-1658-fix: reactivate feature info when switching back from edit

### DIFF
--- a/projects/core/src/lib/components/edit/edit-dialog/edit-dialog.component.ts
+++ b/projects/core/src/lib/components/edit/edit-dialog/edit-dialog.component.ts
@@ -18,6 +18,8 @@ import { FeatureUpdatedService } from '../../../services/feature-updated.service
 import { hideFeatureInfoDialog, reopenFeatureInfoDialog } from '../../feature-info/state/feature-info.actions';
 import { ComponentConfigHelper } from '../../../shared/helpers/component-config.helper';
 import { withLatestFrom } from 'rxjs/operators';
+import { activateTool } from '../../toolbar/state/toolbar.actions';
+import { ToolbarComponentEnum } from '../../toolbar/models/toolbar-component.enum';
 
 @Component({
   selector: 'tm-edit-dialog',
@@ -127,6 +129,7 @@ export class EditDialogComponent {
     this.store$.select(selectEditOpenedFromFeatureInfo).pipe(take(1)).subscribe(openedFromFeatureInfo => {
       if (openedFromFeatureInfo && reopenFeatureInfo) {
         this.store$.dispatch(setEditActive({ active: false }));
+        this.store$.dispatch(activateTool({ tool: ToolbarComponentEnum.FEATURE_INFO }));
         this.store$.dispatch(reopenFeatureInfoDialog());
       }
     });
@@ -164,6 +167,7 @@ export class EditDialogComponent {
           this.resetChanges();
           if (openedFromFeatureInfo) {
             this.store$.dispatch(setEditActive({ active: false }));
+            this.store$.dispatch(activateTool({ tool: ToolbarComponentEnum.FEATURE_INFO }));
             this.store$.dispatch(reopenFeatureInfoDialog());
           }
         }


### PR DESCRIPTION
[![HTM-1658](https://badgen.net/badge/JIRA/HTM-1658/pink?icon=jira)](https://b3partners.atlassian.net/browse/HTM-1658) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=Tailormap&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->



[HTM-1658]: https://b3partners.atlassian.net/browse/HTM-1658?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ