### PR TITLE
HTM-1649: Add a password reset page

### DIFF
--- a/projects/admin-api/src/lib/services/tailormap-admin-api-v1-mock.service.ts
+++ b/projects/admin-api/src/lib/services/tailormap-admin-api-v1-mock.service.ts
@@ -136,10 +136,6 @@ export class TailormapAdminApiV1MockService implements TailormapAdminApiV1Servic
     return of(true).pipe(delay(this.delay));
   }
 
-  public validatePasswordStrength$(_password: string): Observable<boolean> {
-    return of(true).pipe(delay(this.delay));
-  }
-
   public updateUser$(params: { username: string; user: Omit<UserModel, 'groupNames'> & { groups: string[] } }): Observable<UserModel> {
     return of({ ...params.user, groupNames: params.user.groups }).pipe(delay(this.delay));
   }

--- a/projects/admin-api/src/lib/services/tailormap-admin-api-v1-service.model.ts
+++ b/projects/admin-api/src/lib/services/tailormap-admin-api-v1-service.model.ts
@@ -37,7 +37,6 @@ export interface TailormapAdminApiV1ServiceModel {
   createUser$(params: { user: Omit<UserModel, 'groupNames'> & { groups: string[] } }): Observable<UserModel>;
   updateUser$(params: { username: string; user: Partial<Omit<UserModel, 'groupNames'>> & { groups: string[] } }): Observable<UserModel>;
   deleteUser$(username: string): Observable<boolean>;
-  validatePasswordStrength$(password: string): Observable<boolean>;
   getApplications$(): Observable<ApplicationModel[]>;
   createApplication$(params: { application: Partial<Omit<ApplicationModel, 'id'>> }): Observable<ApplicationModel>;
   updateApplication$(params: { id: string; application: Partial<ApplicationModel> }): Observable<ApplicationModel>;

--- a/projects/admin-api/src/lib/services/tailormap-admin-api-v1.service.ts
+++ b/projects/admin-api/src/lib/services/tailormap-admin-api-v1.service.ts
@@ -207,12 +207,6 @@ export class TailormapAdminApiV1Service implements TailormapAdminApiV1ServiceMod
     );
   }
 
-  public validatePasswordStrength$(password: string): Observable<boolean> {
-    const body = new HttpParams().set('password', password);
-    return this.httpClient.post<{ result: boolean }>(`${TailormapAdminApiV1Service.BASE_URL}/validate-password`, body)
-      .pipe(map(response => response.result));
-  }
-
   public getApplications$(): Observable<ApplicationModel[]> {
     return this.httpClient.get<{ _embedded: { applications: ApplicationModel[] }}>(`${TailormapAdminApiV1Service.BASE_URL}/applications?size=1000&sort=title`)
       .pipe(map(response => response._embedded.applications));

--- a/projects/admin-core/src/lib/application/application-form/application-form.component.ts
+++ b/projects/admin-core/src/lib/application/application-form/application-form.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit, ChangeDetectionStrategy, Input, Output, EventEmitter, OnDestroy, inject } from '@angular/core';
 import { AbstractControl, FormControl, FormGroup, ValidationErrors, ValidatorFn, Validators } from '@angular/forms';
-import { BoundsModel, I18nSettingsModel, UiSettingsModel } from '@tailormap-viewer/api';
+import { BoundsModel, I18nSettingsModel, UiSettingsModel, ValidatorsHelper } from '@tailormap-viewer/api';
 import { ApplicationModel, GroupModel, AuthorizationRuleGroup, AUTHORIZATION_RULE_ANONYMOUS } from '@tailormap-admin/admin-api';
 import { Observable, debounceTime, filter, Subject, takeUntil, map, distinctUntilChanged } from 'rxjs';
 import { FormHelper } from '../../helpers/form.helper';
@@ -51,7 +51,7 @@ export class ApplicationFormComponent implements OnInit, OnDestroy {
       nonNullable: true,
       validators: [
         Validators.required,
-        Validators.pattern(FormHelper.NAME_REGEX),
+        Validators.pattern(ValidatorsHelper.NAME_REGEX),
         this.isUniqueApplicationName(),
       ],
     }),

--- a/projects/admin-core/src/lib/helpers/form.helper.ts
+++ b/projects/admin-core/src/lib/helpers/form.helper.ts
@@ -6,8 +6,6 @@ export type ComparableValuesArray = Array<[ValueType, ValueType]>;
 
 export class FormHelper {
 
-  public static NAME_REGEX = /^[a-zA-Z0-9\-_]+$/;
-
   public static isValidValue(value: string | undefined | null) {
     return typeof value !== 'undefined' && value !== null && value.length > 0;
   }

--- a/projects/admin-core/src/lib/user/group-form/group-form.component.ts
+++ b/projects/admin-core/src/lib/user/group-form/group-form.component.ts
@@ -2,10 +2,10 @@ import { ChangeDetectionStrategy, Component, EventEmitter, Input, OnDestroy, OnI
 import { FormControl, FormGroup, Validators } from '@angular/forms';
 import { BehaviorSubject, combineLatest, debounceTime, map, Observable, of, Subject, takeUntil } from 'rxjs';
 import { AdditionalPropertyModel, GroupModel, OIDCConfigurationModel } from '@tailormap-admin/admin-api';
-import { FormHelper } from '../../helpers/form.helper';
 import { AdminFieldLocation, AdminFieldModel, AdminFieldRegistrationService } from '../../shared/services/admin-field-registration.service';
 import { GroupService } from '../services/group.service';
 import { OIDCConfigurationService } from '../../oidc/services/oidc-configuration.service';
+import { ValidatorsHelper } from '@tailormap-viewer/api';
 
 @Component({
   selector: 'tm-admin-group-form',
@@ -23,7 +23,7 @@ export class GroupFormComponent implements OnInit, OnDestroy {
   public groupForm = new FormGroup({
     name: new FormControl<string>('', {
       nonNullable: true,
-      validators: [ Validators.required, Validators.pattern(FormHelper.NAME_REGEX) ],
+      validators: [ Validators.required, Validators.pattern(ValidatorsHelper.NAME_REGEX) ],
     }),
     description: new FormControl<string>('', { nonNullable: false }),
     aliasForGroup: new FormControl<string>('', { nonNullable: false }),

--- a/projects/admin-core/src/lib/user/services/user.service.ts
+++ b/projects/admin-core/src/lib/user/services/user.service.ts
@@ -9,12 +9,14 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { selectUsers, selectUsersLoadStatus } from '../state/user.selectors';
 import { DebounceHelper, LoadingStateEnum } from '@tailormap-viewer/shared';
 import { UserAddUpdateModel } from '../models/user-add-update.model';
+import { TailormapSecurityApiV1Service } from '@tailormap-viewer/api';
 
 @Injectable({
   providedIn: 'root',
 })
 export class UserService {
   private adminApiService = inject(TailormapAdminApiV1Service);
+  private securityApiService = inject(TailormapSecurityApiV1Service);
   private store$ = inject(Store);
   private adminSnackbarService = inject(AdminSnackbarService);
   private sseService = inject(AdminSseService);
@@ -111,7 +113,7 @@ export class UserService {
   }
 
   public validatePasswordStrength$(password: string) {
-    return this.adminApiService.validatePasswordStrength$(password);
+    return this.securityApiService.validatePasswordStrength$(password);
   }
 
   private updateUserState(

--- a/projects/admin-core/src/lib/user/user-form/user-form.component.spec.ts
+++ b/projects/admin-core/src/lib/user/user-form/user-form.component.spec.ts
@@ -10,11 +10,14 @@ import { initialUserState, userStateKey } from '../state/user.state';
 import { MatIconTestingModule } from '@angular/material/icon/testing';
 import { SharedAdminComponentsModule } from '../../shared/components/shared-admin-components.module';
 import { AuthenticatedUserTestHelper } from '../../test-helpers/authenticated-user-test.helper.spec';
+import { TailormapSecurityApiV1Service } from '@tailormap-viewer/api';
 
 const setup = async (isValidPassword: boolean) => {
-  const mockApiService = {
+  const mockAdminApiService = {
     getGroups$: jest.fn(() => of([])),
     getUsers$: jest.fn(() => of([])),
+  };
+  const mockApiService = {
     validatePasswordStrength$: jest.fn(() => of(isValidPassword)),
   };
   const userUpdated = jest.fn();
@@ -23,7 +26,8 @@ const setup = async (isValidPassword: boolean) => {
     declarations: [PasswordFieldComponent],
     on: { userUpdated },
     providers: [
-      { provide: TailormapAdminApiV1Service, useValue: mockApiService },
+      { provide: TailormapAdminApiV1Service, useValue: mockAdminApiService },
+      { provide: TailormapSecurityApiV1Service, useValue: mockApiService },
       provideMockStore({ initialState: { [userStateKey]: initialUserState } }),
       AuthenticatedUserTestHelper.provideAuthenticatedUserServiceWithAdminUser(),
     ],

--- a/projects/admin-core/src/lib/user/user-form/user-form.component.ts
+++ b/projects/admin-core/src/lib/user/user-form/user-form.component.ts
@@ -6,8 +6,8 @@ import { GroupService } from '../services/group.service';
 import { formatDate } from '@angular/common';
 import { UserService } from '../services/user.service';
 import { UserAddUpdateModel } from '../models/user-add-update.model';
-import { FormHelper } from '../../helpers/form.helper';
 import { AdminFieldLocation, AdminFieldModel, AdminFieldRegistrationService } from '../../shared/services/admin-field-registration.service';
+import { ValidatorsHelper } from '@tailormap-viewer/api';
 
 @Component({
   selector: 'tm-admin-user-form',
@@ -25,7 +25,7 @@ export class UserFormComponent implements OnInit, OnDestroy {
   public userForm = new FormGroup({
     username: new FormControl<string>('', {
       nonNullable: true,
-      validators: [ Validators.required, Validators.pattern(FormHelper.NAME_REGEX) ],
+      validators: [ Validators.required, Validators.pattern(ValidatorsHelper.NAME_REGEX) ],
     }),
     password: new FormControl<string>('', {
       nonNullable: true,

--- a/projects/admin-core/src/lib/user/user-list/user-list.component.spec.ts
+++ b/projects/admin-core/src/lib/user/user-list/user-list.component.spec.ts
@@ -8,16 +8,19 @@ import { provideMockStore } from '@ngrx/store/testing';
 import { initialUserState, userStateKey } from '../state/user.state';
 import { AuthenticatedUserTestHelper } from '../../test-helpers/authenticated-user-test.helper.spec';
 import { SharedAdminComponentsModule } from '../../shared/components/shared-admin-components.module';
+import { TailormapSecurityApiV1Service } from '@tailormap-viewer/api';
 
 const setup = async () => {
-  const mockApiService = {
+  const mockAdminApiService = {
     getUsers$: jest.fn(() => of(getUsers)),
   };
+  const mockApiService = {};
 
   await render(UserListComponent, {
     imports: [ SharedModule, MatListModule, SharedAdminComponentsModule ],
     providers: [
-      { provide: TailormapAdminApiV1Service, useValue: mockApiService },
+      { provide: TailormapAdminApiV1Service, useValue: mockAdminApiService },
+      { provide: TailormapSecurityApiV1Service, useValue: mockApiService },
       provideMockStore({ initialState: { [userStateKey]: initialUserState } }),
       AuthenticatedUserTestHelper.provideAuthenticatedUserServiceWithAdminUser(),
     ],

--- a/projects/api/src/lib/helpers/index.ts
+++ b/projects/api/src/lib/helpers/index.ts
@@ -2,3 +2,4 @@ export * from './api.helper';
 export * from './attribute-type.helper';
 export * from './base-component-config.helper';
 export * from './uploaded-image.helper';
+export * from './validators.helper';

--- a/projects/api/src/lib/helpers/validators.helper.ts
+++ b/projects/api/src/lib/helpers/validators.helper.ts
@@ -1,0 +1,3 @@
+export class ValidatorsHelper {
+  public static NAME_REGEX = /^[a-zA-Z0-9\-_]+$/;
+}

--- a/projects/api/src/lib/services/tailormap-security-api-v1-mock.service.ts
+++ b/projects/api/src/lib/services/tailormap-security-api-v1-mock.service.ts
@@ -1,11 +1,13 @@
 import { Injectable } from '@angular/core';
 import { LoginConfigurationModel, UserResponseModel } from '../models';
-import { Observable, of } from 'rxjs';
+import { delay, Observable, of } from 'rxjs';
 import { getLoginConfigurationModel, getUserResponseModel } from '../mock-data';
 import { TailormapSecurityApiV1ServiceModel } from './tailormap-security-api-v1.service.model';
 
 @Injectable()
 export class TailormapSecurityApiV1MockService implements TailormapSecurityApiV1ServiceModel {
+  public delay = 3000;
+
   public getLoginConfiguration$(): Observable<LoginConfigurationModel> {
       return of(getLoginConfigurationModel());
   }
@@ -24,5 +26,13 @@ export class TailormapSecurityApiV1MockService implements TailormapSecurityApiV1
 
   public requestPasswordReset$(): Observable<boolean> {
     return of(true);
+  }
+
+  public validatePasswordStrength$(_password: string): Observable<boolean> {
+    return of(true).pipe(delay(this.delay));
+  }
+
+  public resetPassword$(_token: string, _username: string, _newPassword: string): Observable<boolean> {
+    return of(true).pipe(delay(this.delay));
   }
 }

--- a/projects/api/src/lib/services/tailormap-security-api-v1.service.model.ts
+++ b/projects/api/src/lib/services/tailormap-security-api-v1.service.model.ts
@@ -8,4 +8,6 @@ export interface TailormapSecurityApiV1ServiceModel {
   login$(username: string, password: string): Observable<UserResponseModel>;
   logout$(): Observable<boolean>;
   requestPasswordReset$(email: string): Observable<boolean>;
+  validatePasswordStrength$(password: string): Observable<boolean>;
+  resetPassword$(token: string, username: string, newPassword: string): Observable<boolean>;
 }

--- a/projects/api/src/lib/services/tailormap-security-api-v1.service.ts
+++ b/projects/api/src/lib/services/tailormap-security-api-v1.service.ts
@@ -6,7 +6,9 @@ import { TailormapSecurityApiV1ServiceModel } from './tailormap-security-api-v1.
 import { TailormapApiConstants } from './tailormap-api.constants';
 import { ExtendedUserResponseModel } from '../models/extended-user-response.model';
 
-@Injectable()
+@Injectable(
+  { providedIn: 'root' },
+)
 export class TailormapSecurityApiV1Service implements TailormapSecurityApiV1ServiceModel {
 
   private httpClient = inject(HttpClient);
@@ -84,7 +86,7 @@ export class TailormapSecurityApiV1Service implements TailormapSecurityApiV1Serv
 
   public resetPassword$(token: string, username: string, newPassword: string): Observable<boolean> {
     const body = new HttpParams().set('token', token).set('username', username).set('newPassword', newPassword);
-    return this.httpClient.post(`${TailormapApiConstants.BASE_URL}/password-reset/confirm`, body, { observe: 'response' }).pipe(
+    return this.httpClient.post(`${TailormapApiConstants.BASE_URL}/user/reset-password`, body, { observe: 'response' }).pipe(
       map(response => response.status === 200),
       catchError(() => of(false)),
     );

--- a/projects/api/src/lib/services/tailormap-security-api-v1.service.ts
+++ b/projects/api/src/lib/services/tailormap-security-api-v1.service.ts
@@ -75,4 +75,18 @@ export class TailormapSecurityApiV1Service implements TailormapSecurityApiV1Serv
       catchError(() => of(false)),
     );
   }
+
+  public validatePasswordStrength$(password: string): Observable<boolean> {
+    const body = new HttpParams().set('password', password);
+    return this.httpClient.post<{ result: boolean }>(`${TailormapApiConstants.BASE_URL}/validate-password`, body)
+      .pipe(map(response => response.result));
+  }
+
+  public resetPassword$(token: string, username: string, newPassword: string): Observable<boolean> {
+    const body = new HttpParams().set('token', token).set('username', username).set('newPassword', newPassword);
+    return this.httpClient.post(`${TailormapApiConstants.BASE_URL}/password-reset/confirm`, body, { observe: 'response' }).pipe(
+      map(response => response.status === 200),
+      catchError(() => of(false)),
+    );
+  }
 }

--- a/projects/core/assets/locale/messages.core.de.xlf
+++ b/projects/core/assets/locale/messages.core.de.xlf
@@ -914,7 +914,7 @@
         <source>Your password reset token is invalid or has expired.</source>
         <target>Ihr Passwort-Reset-Token ist ungültig oder abgelaufen.</target>
       </trans-unit>
-      <trans-unit id="core.password-reset-form.succes" datatype="html">
+      <trans-unit id="core.password-reset-form.success" datatype="html">
         <source>Password successfully reset, you can now log in with your new password.</source>
         <target>Passwort erfolgreich zurückgesetzt, Sie können sich jetzt mit Ihrem neuen Passwort anmelden.</target>
       </trans-unit>

--- a/projects/core/assets/locale/messages.core.de.xlf
+++ b/projects/core/assets/locale/messages.core.de.xlf
@@ -878,6 +878,62 @@
         <source>You are logged in <x id="PH" equiv-text="userLabel"/> but do not have proper roles to access the application. Please contact your administrator.</source>
         <target>Sie sind als <x id="PH" equiv-text="userLabel"/> angemeldet, haben jedoch nicht die erforderlichen Rollen, um auf die Anwendung zuzugreifen. Bitte kontaktieren Sie Ihren Administrator.</target>
       </trans-unit>
+      <trans-unit id="core.password-reset-form.title" datatype="html">
+        <source>Reset Password</source>
+        <target>Passwort zurücksetzen</target>
+      </trans-unit>
+      <trans-unit id="core.password-reset-form.username" datatype="html">
+        <source>Username</source>
+        <target>Benutzername</target>
+      </trans-unit>
+      <trans-unit id="core.password-reset-form.newpassword" datatype="html">
+        <source>New Password</source>
+        <target>Neues Passwort</target>
+      </trans-unit>
+      <trans-unit id="core.password-reset-form.confirmedpassword" datatype="html">
+        <source>Confirm Password</source>
+        <target>Passwort bestätigen</target>
+      </trans-unit>
+      <trans-unit id="core.password-reset-form.error.username-invalid" datatype="html">
+        <source>Username is invalid</source>
+        <target>Benutzername ist ungültig</target>
+      </trans-unit>
+      <trans-unit id="core.password-reset-form.error.password-tooshort" datatype="html">
+        <source>Password shorter than <x id="PH" equiv-text="passwordResetForm.controls.newPassword.errors?.['minlength'].requiredLength"/></source>
+        <target>Passwort kürzer als <x id="PH" equiv-text="passwordResetForm.controls.newPassword.errors?.['minlength'].requiredLength"/></target>
+      </trans-unit>
+      <trans-unit id="core.password-reset-form.error.password-toosimple" datatype="html">
+        <source>Password too short or too easily guessable</source>
+        <target>Passwort zu kurz oder zu einfach zu erraten</target>
+      </trans-unit>
+      <trans-unit id="core.password-reset-form.error.need-match" datatype="html">
+        <source>Passwords need to match</source>
+        <target>Passwörter müssen übereinstimmen</target>
+      </trans-unit>
+      <trans-unit id="core.password-reset-form.error.token-expired" datatype="html">
+        <source>Your password reset token is invalid or has expired.</source>
+        <target>Ihr Passwort-Reset-Token ist ungültig oder abgelaufen.</target>
+      </trans-unit>
+      <trans-unit id="core.password-reset-form.succes" datatype="html">
+        <source>Password successfully reset, you can now log in with your new password.</source>
+        <target>Passwort erfolgreich zurückgesetzt, Sie können sich jetzt mit Ihrem neuen Passwort anmelden.</target>
+      </trans-unit>
+      <trans-unit id="core.password-reset-form.error-saving" datatype="html">
+        <source>Error saving password, please check your token, username and password and try again.</source>
+        <target>Fehler beim Speichern des Passworts, bitte überprüfen Sie Ihr Token, Ihren Benutzernamen und Ihr Passwort und versuchen Sie es erneut.</target>
+      </trans-unit>
+      <trans-unit id="core.password-reset-form.error-reset" datatype="html">
+        <source>Error resetting password: <x id="PH" equiv-text="(error?.error?.message || error?.message || error.toString())"/></source>
+        <target>Fehler beim Zurücksetzen des Passworts: <x id="PH" equiv-text="(error?.error?.message || error?.message || error.toString())"/></target>
+      </trans-unit>
+      <trans-unit id="core.password-reset-form.save" datatype="html">
+        <source>Save new password</source>
+        <target>Neues Passwort speichern</target>
+      </trans-unit>
+      <trans-unit id="core.password-reset-form.return" datatype="html">
+        <source>Return to Login</source>
+        <target>Zurück zum Login</target>
+      </trans-unit>
       <trans-unit id="core.print.a3" datatype="html">
         <source>A3</source>
         <target>A3</target>

--- a/projects/core/assets/locale/messages.core.de.xlf
+++ b/projects/core/assets/locale/messages.core.de.xlf
@@ -899,8 +899,8 @@
         <target>Benutzername ist ungültig</target>
       </trans-unit>
       <trans-unit id="core.password-reset-form.error.password-tooshort" datatype="html">
-        <source>Password shorter than <x id="PH" equiv-text="passwordResetForm.controls.newPassword.errors?.['minlength'].requiredLength"/></source>
-        <target>Passwort kürzer als <x id="PH" equiv-text="passwordResetForm.controls.newPassword.errors?.['minlength'].requiredLength"/></target>
+        <source>Password shorter than <x id="INTERPOLATION" equiv-text="passwordResetForm.controls.newPassword.errors?.['minlength'].requiredLength"/></source>
+        <target>Passwort kürzer als <x id="INTERPOLATION" equiv-text="passwordResetForm.controls.newPassword.errors?.['minlength'].requiredLength"/></target>
       </trans-unit>
       <trans-unit id="core.password-reset-form.error.password-toosimple" datatype="html">
         <source>Password too short or too easily guessable</source>

--- a/projects/core/assets/locale/messages.core.en.xlf
+++ b/projects/core/assets/locale/messages.core.en.xlf
@@ -909,49 +909,48 @@
       <trans-unit id="core.user-login-check-viewer-message" datatype="html">
         <source>You are logged out and might need to login again</source>
       </trans-unit>
-      <trans-unit id="shared.password-reset-form.title" datatype="html">
+      <trans-unit id="core.password-reset-form.title" datatype="html">
         <source>Reset Password</source>
       </trans-unit>
-      <trans-unit id="shared.password-reset-form.username" datatype="html">
+      <trans-unit id="core.password-reset-form.username" datatype="html">
         <source>Username</source>
       </trans-unit>
-      <trans-unit id="shared.password-reset-form.newpassword" datatype="html">
+      <trans-unit id="core.password-reset-form.newpassword" datatype="html">
         <source>New Password</source>
       </trans-unit>
-      <trans-unit id="shared.password-reset-form.confirmedpassword" datatype="html">
+      <trans-unit id="core.password-reset-form.confirmedpassword" datatype="html">
         <source>Confirm Password</source>
       </trans-unit>
-      <trans-unit id="shared.password-reset-form.error.username-invalid" datatype="html">
+      <trans-unit id="core.password-reset-form.error.username-invalid" datatype="html">
         <source>Username is invalid</source>
       </trans-unit>
-      <trans-unit id="shared.password-reset-form.error.password-tooshort" datatype="html">
+      <trans-unit id="core.password-reset-form.error.password-tooshort" datatype="html">
         <source>Password shorter than <x id="PH" equiv-text="passwordResetForm.controls.newPassword.errors?.['minlength'].requiredLength"/></source>
       </trans-unit>
-      <trans-unit id="shared.password-reset-form.error.password-toosimple" datatype="html">
+      <trans-unit id="core.password-reset-form.error.password-toosimple" datatype="html">
         <source>Password too short or too easily guessable</source>
       </trans-unit>
-      <trans-unit id="shared.password-reset-form.error.need-match" datatype="html">
+      <trans-unit id="core.password-reset-form.error.need-match" datatype="html">
         <source>Passwords need to match</source>
       </trans-unit>
-      <trans-unit id="shared.password-reset-form.error.token-expired" datatype="html">
+      <trans-unit id="core.password-reset-form.error.token-expired" datatype="html">
         <source>Your password reset token is invalid or has expired.</source>
       </trans-unit>
-      <trans-unit id="shared.password-reset-form.succes" datatype="html">
+      <trans-unit id="core.password-reset-form.succes" datatype="html">
         <source>Password successfully reset, you can now log in with your new password.</source>
       </trans-unit>
-      <trans-unit id="shared.password-reset-form.error-saving" datatype="html">
+      <trans-unit id="core.password-reset-form.error-saving" datatype="html">
         <source>Error saving password, please check your token, username and password and try again.</source>
       </trans-unit>
-      <trans-unit id="shared.password-reset-form.error-reset" datatype="html">
+      <trans-unit id="core.password-reset-form.error-reset" datatype="html">
         <source>Error resetting password: <x id="PH" equiv-text="(error?.error?.message || error?.message || error.toString())"/></source>
       </trans-unit>
-      <trans-unit id="shared.password-reset-form.save" datatype="html">
+      <trans-unit id="core.password-reset-form.save" datatype="html">
         <source>Save new password</source>
       </trans-unit>
-      <trans-unit id="shared.password-reset-form.return" datatype="html">
+      <trans-unit id="core.password-reset-form.return" datatype="html">
         <source>Return to Login</source>
       </trans-unit>
-
     </body>
   </file>
 </xliff>

--- a/projects/core/assets/locale/messages.core.en.xlf
+++ b/projects/core/assets/locale/messages.core.en.xlf
@@ -936,7 +936,7 @@
       <trans-unit id="core.password-reset-form.error.token-expired" datatype="html">
         <source>Your password reset token is invalid or has expired.</source>
       </trans-unit>
-      <trans-unit id="core.password-reset-form.succes" datatype="html">
+      <trans-unit id="core.password-reset-form.success" datatype="html">
         <source>Password successfully reset, you can now log in with your new password.</source>
       </trans-unit>
       <trans-unit id="core.password-reset-form.error-saving" datatype="html">

--- a/projects/core/assets/locale/messages.core.en.xlf
+++ b/projects/core/assets/locale/messages.core.en.xlf
@@ -900,6 +900,49 @@
       <trans-unit id="core.user-login-check-viewer-message" datatype="html">
         <source>You are logged out and might need to login again</source>
       </trans-unit>
+      <trans-unit id="shared.password-reset-form.title" datatype="html">
+        <source>Reset Password</source>
+      </trans-unit>
+      <trans-unit id="shared.password-reset-form.username" datatype="html">
+        <source>Username</source>
+      </trans-unit>
+      <trans-unit id="shared.password-reset-form.newpassword" datatype="html">
+        <source>New Password</source>
+      </trans-unit>
+      <trans-unit id="shared.password-reset-form.confirmedpassword" datatype="html">
+        <source>Confirm Password</source>
+      </trans-unit>
+      <trans-unit id="shared.password-reset-form.error.username-invalid" datatype="html">
+        <source>Username is invalid</source>
+      </trans-unit>
+      <trans-unit id="shared.password-reset-form.error.password-tooshort" datatype="html">
+        <source>Password shorter than <x id="PH" equiv-text="passwordResetForm.controls.newPassword.errors?.['minlength'].requiredLength"/></source>
+      </trans-unit>
+      <trans-unit id="shared.password-reset-form.error.password-toosimple" datatype="html">
+        <source>Password too short or too easily guessable</source>
+      </trans-unit>
+      <trans-unit id="shared.password-reset-form.error.need-match" datatype="html">
+        <source>Passwords need to match</source>
+      </trans-unit>
+      <trans-unit id="shared.password-reset-form.error.token-expired" datatype="html">
+        <source>Your password reset token is invalid or has expired.</source>
+      </trans-unit>
+      <trans-unit id="shared.password-reset-form.succes" datatype="html">
+        <source>Password successfully reset, you can now log in with your new password.</source>
+      </trans-unit>
+      <trans-unit id="shared.password-reset-form.error-saving" datatype="html">
+        <source>Error saving password, please check your token, username and password and try again.</source>
+      </trans-unit>
+      <trans-unit id="shared.password-reset-form.error-reset" datatype="html">
+        <source>Error resetting password: <x id="PH" equiv-text="(error?.error?.message || error?.message || error.toString())"/></source>
+      </trans-unit>
+      <trans-unit id="shared.password-reset-form.save" datatype="html">
+        <source>Save new password</source>
+      </trans-unit>
+      <trans-unit id="shared.password-reset-form.return" datatype="html">
+        <source>Return to Login</source>
+      </trans-unit>
+
     </body>
   </file>
 </xliff>

--- a/projects/core/assets/locale/messages.core.en.xlf
+++ b/projects/core/assets/locale/messages.core.en.xlf
@@ -909,6 +909,49 @@
       <trans-unit id="core.user-login-check-viewer-message" datatype="html">
         <source>You are logged out and might need to login again</source>
       </trans-unit>
+      <trans-unit id="shared.password-reset-form.title" datatype="html">
+        <source>Reset Password</source>
+      </trans-unit>
+      <trans-unit id="shared.password-reset-form.username" datatype="html">
+        <source>Username</source>
+      </trans-unit>
+      <trans-unit id="shared.password-reset-form.newpassword" datatype="html">
+        <source>New Password</source>
+      </trans-unit>
+      <trans-unit id="shared.password-reset-form.confirmedpassword" datatype="html">
+        <source>Confirm Password</source>
+      </trans-unit>
+      <trans-unit id="shared.password-reset-form.error.username-invalid" datatype="html">
+        <source>Username is invalid</source>
+      </trans-unit>
+      <trans-unit id="shared.password-reset-form.error.password-tooshort" datatype="html">
+        <source>Password shorter than <x id="PH" equiv-text="passwordResetForm.controls.newPassword.errors?.['minlength'].requiredLength"/></source>
+      </trans-unit>
+      <trans-unit id="shared.password-reset-form.error.password-toosimple" datatype="html">
+        <source>Password too short or too easily guessable</source>
+      </trans-unit>
+      <trans-unit id="shared.password-reset-form.error.need-match" datatype="html">
+        <source>Passwords need to match</source>
+      </trans-unit>
+      <trans-unit id="shared.password-reset-form.error.token-expired" datatype="html">
+        <source>Your password reset token is invalid or has expired.</source>
+      </trans-unit>
+      <trans-unit id="shared.password-reset-form.succes" datatype="html">
+        <source>Password successfully reset, you can now log in with your new password.</source>
+      </trans-unit>
+      <trans-unit id="shared.password-reset-form.error-saving" datatype="html">
+        <source>Error saving password, please check your token, username and password and try again.</source>
+      </trans-unit>
+      <trans-unit id="shared.password-reset-form.error-reset" datatype="html">
+        <source>Error resetting password: <x id="PH" equiv-text="(error?.error?.message || error?.message || error.toString())"/></source>
+      </trans-unit>
+      <trans-unit id="shared.password-reset-form.save" datatype="html">
+        <source>Save new password</source>
+      </trans-unit>
+      <trans-unit id="shared.password-reset-form.return" datatype="html">
+        <source>Return to Login</source>
+      </trans-unit>
+
     </body>
   </file>
 </xliff>

--- a/projects/core/assets/locale/messages.core.en.xlf
+++ b/projects/core/assets/locale/messages.core.en.xlf
@@ -925,7 +925,7 @@
         <source>Username is invalid</source>
       </trans-unit>
       <trans-unit id="core.password-reset-form.error.password-tooshort" datatype="html">
-        <source>Password shorter than <x id="PH" equiv-text="passwordResetForm.controls.newPassword.errors?.['minlength'].requiredLength"/></source>
+        <source>Password shorter than <x id="INTERPOLATION" equiv-text="passwordResetForm.controls.newPassword.errors?.['minlength'].requiredLength"/></source>
       </trans-unit>
       <trans-unit id="core.password-reset-form.error.password-toosimple" datatype="html">
         <source>Password too short or too easily guessable</source>

--- a/projects/core/assets/locale/messages.core.nl.xlf
+++ b/projects/core/assets/locale/messages.core.nl.xlf
@@ -899,8 +899,8 @@
         <target>Gebruikersnaam is ongeldig</target>
       </trans-unit>
       <trans-unit id="core.password-reset-form.error.password-tooshort" datatype="html">
-        <source>Password shorter than <x id="PH" equiv-text="passwordResetForm.controls.newPassword.errors?.['minlength'].requiredLength"/></source>
-        <target>Wachtwoord korter dan <x id="PH" equiv-text="passwordResetForm.controls.newPassword.errors?.['minlength'].requiredLength"/></target>
+        <source>Password shorter than <x id="INTERPOLATION" equiv-text="passwordResetForm.controls.newPassword.errors?.['minlength'].requiredLength"/></source>
+        <target>Wachtwoord korter dan <x id="INTERPOLATION" equiv-text="passwordResetForm.controls.newPassword.errors?.['minlength'].requiredLength"/></target>
       </trans-unit>
       <trans-unit id="core.password-reset-form.error.password-toosimple" datatype="html">
         <source>Password too short or too easily guessable</source>

--- a/projects/core/assets/locale/messages.core.nl.xlf
+++ b/projects/core/assets/locale/messages.core.nl.xlf
@@ -878,6 +878,62 @@
         <source>You are logged in <x id="PH" equiv-text="userLabel"/> but do not have proper roles to access the application. Please contact your administrator.</source>
         <target>Je bent ingelogd <x id="PH" equiv-text="userLabel"/> maar je hebt niet de juiste rollen om toegang te krijgen tot de applicatie. Neem contact op met uw beheerder.</target>
       </trans-unit>
+      <trans-unit id="core.password-reset-form.title" datatype="html">
+        <source>Reset Password</source>
+        <target>Wachtwoord opnieuw instellen</target>
+      </trans-unit>
+      <trans-unit id="core.password-reset-form.username" datatype="html">
+        <source>Username</source>
+        <target>Gebruikersnaam</target>
+      </trans-unit>
+      <trans-unit id="core.password-reset-form.newpassword" datatype="html">
+        <source>New Password</source>
+        <target>Nieuw wachtwoord</target>
+      </trans-unit>
+      <trans-unit id="core.password-reset-form.confirmedpassword" datatype="html">
+        <source>Confirm Password</source>
+        <target>Bevestig wachtwoord</target>
+      </trans-unit>
+      <trans-unit id="core.password-reset-form.error.username-invalid" datatype="html">
+        <source>Username is invalid</source>
+        <target>Gebruikersnaam is ongeldig</target>
+      </trans-unit>
+      <trans-unit id="core.password-reset-form.error.password-tooshort" datatype="html">
+        <source>Password shorter than <x id="PH" equiv-text="passwordResetForm.controls.newPassword.errors?.['minlength'].requiredLength"/></source>
+        <target>Wachtwoord korter dan <x id="PH" equiv-text="passwordResetForm.controls.newPassword.errors?.['minlength'].requiredLength"/></target>
+      </trans-unit>
+      <trans-unit id="core.password-reset-form.error.password-toosimple" datatype="html">
+        <source>Password too short or too easily guessable</source>
+        <target>Wachtwoord te kort of te makkelijk te raden</target>
+      </trans-unit>
+      <trans-unit id="core.password-reset-form.error.need-match" datatype="html">
+        <source>Passwords need to match</source>
+        <target>Wachtwoorden moeten overeenkomen</target>
+      </trans-unit>
+      <trans-unit id="core.password-reset-form.error.token-expired" datatype="html">
+        <source>Your password reset token is invalid or has expired.</source>
+        <target>Uw wachtwoord-reset-token is ongeldig of verlopen.</target>
+      </trans-unit>
+      <trans-unit id="core.password-reset-form.succes" datatype="html">
+        <source>Password successfully reset, you can now log in with your new password.</source>
+        <target>Wachtwoord succesvol opnieuw ingesteld, u kunt nu inloggen met uw nieuwe wachtwoord.</target>
+      </trans-unit>
+      <trans-unit id="core.password-reset-form.error-saving" datatype="html">
+        <source>Error saving password, please check your token, username and password and try again.</source>
+        <target>Fout bij het opslaan van het wachtwoord, controleer uw token, gebruikersnaam en wachtwoord en probeer het opnieuw.</target>
+      </trans-unit>
+      <trans-unit id="core.password-reset-form.error-reset" datatype="html">
+        <source>Error resetting password: <x id="PH" equiv-text="(error?.error?.message || error?.message || error.toString())"/></source>
+        <target>Fout bij het opnieuw instellen van het wachtwoord: <x id="PH" equiv-text="(error?.error?.message || error?.message || error.toString())"/></target>
+      </trans-unit>
+      <trans-unit id="core.password-reset-form.save" datatype="html">
+        <source>Save new password</source>
+        <target>Nieuw wachtwoord opslaan</target>
+      </trans-unit>
+      <trans-unit id="core.password-reset-form.return" datatype="html">
+        <source>Return to Login</source>
+        <target>Terug naar inloggen</target>
+      </trans-unit>
       <trans-unit id="core.print.a3" datatype="html">
         <source>A3</source>
         <target>A3</target>

--- a/projects/core/assets/locale/messages.core.nl.xlf
+++ b/projects/core/assets/locale/messages.core.nl.xlf
@@ -914,7 +914,7 @@
         <source>Your password reset token is invalid or has expired.</source>
         <target>Uw wachtwoord-reset-token is ongeldig of verlopen.</target>
       </trans-unit>
-      <trans-unit id="core.password-reset-form.succes" datatype="html">
+      <trans-unit id="core.password-reset-form.success" datatype="html">
         <source>Password successfully reset, you can now log in with your new password.</source>
         <target>Wachtwoord succesvol opnieuw ingesteld, u kunt nu inloggen met uw nieuwe wachtwoord.</target>
       </trans-unit>

--- a/projects/core/src/lib/core-routing.module.ts
+++ b/projects/core/src/lib/core-routing.module.ts
@@ -1,11 +1,11 @@
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
-import { LoginComponent, ViewerAppComponent } from './pages';
+import { LoginComponent,  ViewerAppComponent, PasswordResetComponent } from './pages';
 import { NavigationErrorRouterService } from './services/navigation-error-router.service';
 
 const routes: Routes = [
   { path: 'login', component: LoginComponent },
-  { path: 'user', component: LoginComponent },
+  { path: 'user/password-reset/:token', component: PasswordResetComponent },
   { path: 'app/:name', component: ViewerAppComponent },
   { path: 'app', component: ViewerAppComponent },
   { path: 'service/:name', component: ViewerAppComponent },

--- a/projects/core/src/lib/core.module.ts
+++ b/projects/core/src/lib/core.module.ts
@@ -1,5 +1,5 @@
 import { InjectionToken, ModuleWithProviders, NgModule, inject, provideAppInitializer } from '@angular/core';
-import { LoginComponent, ViewerAppComponent } from './pages';
+import { PasswordResetComponent, LoginComponent, ViewerAppComponent } from './pages';
 import { MapModule } from '@tailormap-viewer/map';
 import { StoreModule } from '@ngrx/store';
 import { EffectsModule } from '@ngrx/effects';
@@ -56,6 +56,7 @@ const sentryProviders = SENTRY_DSN === '@SENTRY_DSN@' ? [] : [
     LoginComponent,
     LoginFormComponent,
     PasswordResetRequestFormComponent,
+    PasswordResetComponent,
   ],
   imports: [
     CoreRoutingModule,

--- a/projects/core/src/lib/pages/index.ts
+++ b/projects/core/src/lib/pages/index.ts
@@ -1,2 +1,3 @@
 export * from './viewer-app/viewer-app.component';
 export * from './login/login.component';
+export * from './password-reset/password-reset.component';

--- a/projects/core/src/lib/pages/login/password-reset-request-form/password-reset-request-form.component.css
+++ b/projects/core/src/lib/pages/login/password-reset-request-form/password-reset-request-form.component.css
@@ -37,3 +37,10 @@
 button mat-spinner {
   margin: 8px;
 }
+
+.password-reset-request-form__body .login-link {
+  padding-bottom: 4px;
+  padding-right: 4px;
+  text-align: right;
+  cursor: pointer;
+}

--- a/projects/core/src/lib/pages/login/password-reset-request-form/password-reset-request-form.component.html
+++ b/projects/core/src/lib/pages/login/password-reset-request-form/password-reset-request-form.component.html
@@ -35,5 +35,9 @@
       </button>
     </div>
 
+    <div class="login-link">
+      <a i18n="@@core.password-reset-form.return" routerLink="/login">Return to Login</a>
+    </div>
+
   </div>
 </div>

--- a/projects/core/src/lib/pages/password-reset/password-reset.component.css
+++ b/projects/core/src/lib/pages/password-reset/password-reset.component.css
@@ -1,0 +1,60 @@
+:host,
+.password-reset-wrapper {
+  width: 100%;
+  height: 100%;
+}
+
+.password-reset-wrapper {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.password-reset-form {
+  width: 500px;
+  max-width: 90vw;
+  border-radius: 6px;
+  background-color: #FFFFFF;
+  box-shadow: 0 1px 0 0 rgba(0, 0, 0, 0.05), 0 10px 28px 0 rgba(0, 0, 0, 0.08);
+}
+
+.password-reset-form__header {
+  padding: 14px 17px;
+  border-bottom: 1px solid var(--border-color);
+  font-size: 22px;
+  display: flex;
+  align-items: center;
+}
+
+.password-reset-form__header > div {
+  flex: 1;
+}
+
+.logo {
+  width: 40px;
+  height: 40px;
+}
+
+.password-reset-form__body {
+  padding: 14px 17px 24px 17px;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.password-reset-form__body .token-validity {
+  margin-bottom: 16px;
+  color: var(--info-color);
+}
+
+
+.password-reset-form__body .buttons {
+  display: flex;
+  justify-content: flex-end;
+  padding: 16px 0 16px 16px;
+}
+
+.password-reset-form__body .login-link {
+  padding-bottom: 4px;
+  padding-right: 4px;
+  text-align: right;
+  cursor: pointer;
+}

--- a/projects/core/src/lib/pages/password-reset/password-reset.component.html
+++ b/projects/core/src/lib/pages/password-reset/password-reset.component.html
@@ -1,0 +1,78 @@
+<div class="password-reset-wrapper">
+
+  <div [formGroup]="passwordResetForm" class="password-reset-form">
+
+    <div class="password-reset-form__header">
+      <div i18n="@@shared.password-reset-form.title">Reset Password</div>
+      <mat-icon class="logo" svgIcon="logo"></mat-icon>
+    </div>
+
+    <div class="password-reset-form__body">
+      <tm-error-message [message]="(errorMessage$ | async) ?? ''"/>
+      <tm-info-message [message]="(infoMessage$ | async) ?? ''"/>
+
+      <p class="token-validity">Reset token is valid until {{ token.tokenValidUntil | date:'medium' }}</p>
+
+      <div class="form-field">
+        <label for="username" i18n="@@shared.password-reset-form.username">Username</label>
+        <input
+          [tmAutoFocus]="true"
+          formControlName="username"
+          id="username"
+          name="username"
+          type="text"
+        />
+        @if (passwordResetForm.controls.username.errors) {
+          <mat-error i18n="@@shared.password-reset-form.error.username-invalid">Username is invalid</mat-error>
+        }
+      </div>
+
+      <div class="form-field">
+        <label for="newPassword" i18n="@@shared.password-reset-form.newpassword">New Password</label>
+        <input
+          formControlName="newPassword"
+          id="newPassword"
+          name="newPassword"
+          type="password"
+        />
+        @if (passwordResetForm.controls.newPassword.errors?.['minlength']) {
+          <mat-error i18n="@@shared.password-reset-form.error.password-tooshort">Password shorter
+            than {{ passwordResetForm.controls.newPassword.errors?.['minlength'].requiredLength }}
+          </mat-error>
+        }
+        @if (passwordResetForm.controls.newPassword.errors?.['weakPassword']) {
+          <mat-error i18n="@@shared.password-reset-form.error.password-toosimple">Password too short or too easily guessable</mat-error>
+        }
+      </div>
+
+      <div class="form-field">
+        <label for="confirmedPassword" i18n="@@shared.password-reset-form.confirmedpassword">Confirm Password</label>
+        <input
+          formControlName="confirmedPassword"
+          id="confirmedPassword"
+          name="confirmedPassword"
+          type="password"
+        />
+        @if (passwordResetForm.controls.confirmedPassword.errors?.['passwordMismatch']) {
+          <mat-error i18n="@@shared.password-reset-form.error.need-match">Passwords need to match</mat-error>
+        }
+      </div>
+
+      <div class="buttons">
+        <button (click)="savePassword()"
+                [disabled]="passwordResetForm.invalid"
+                color="primary"
+                mat-flat-button
+                name="login">
+          <span i18n="@@shared.password-reset-form.save">Save new password</span>
+        </button>
+      </div>
+
+      <div class="login-link">
+        <a i18n="@@shared.password-reset-form.return" routerLink="/login">Return to Login</a>
+      </div>
+
+    </div>
+
+  </div>
+</div>

--- a/projects/core/src/lib/pages/password-reset/password-reset.component.html
+++ b/projects/core/src/lib/pages/password-reset/password-reset.component.html
@@ -13,59 +13,62 @@
 
       <p class="token-validity">Reset token is valid until {{ token.tokenValidUntil | date:'medium' }}</p>
 
-      <div class="form-field">
-        <label for="username" i18n="@@core.password-reset-form.username">Username</label>
-        <input
-          [tmAutoFocus]="true"
-          formControlName="username"
-          id="username"
-          name="username"
-          type="text"
-        />
-        @if (passwordResetForm.controls.username.errors) {
-          <mat-error i18n="@@core.password-reset-form.error.username-invalid">Username is invalid</mat-error>
-        }
-      </div>
+      @if (tokenIsValid()) {
+        <div class="form-field">
+          <label for="username" i18n="@@core.password-reset-form.username">Username</label>
+          <input
+            [tmAutoFocus]="true"
+            formControlName="username"
+            id="username"
+            name="username"
+            type="text"
+          />
+          @if (passwordResetForm.controls.username.errors) {
+            <mat-error i18n="@@core.password-reset-form.error.username-invalid">Username is invalid</mat-error>
+          }
+        </div>
 
-      <div class="form-field">
-        <label for="newPassword" i18n="@@core.password-reset-form.newpassword">New Password</label>
-        <input
-          formControlName="newPassword"
-          id="newPassword"
-          name="newPassword"
-          type="password"
-        />
-        @if (passwordResetForm.controls.newPassword.errors?.['minlength']) {
-          <mat-error i18n="@@core.password-reset-form.error.password-tooshort">Password shorter than {{ passwordResetForm.controls.newPassword.errors?.['minlength'].requiredLength }}</mat-error>
-        }
-        @if (passwordResetForm.controls.newPassword.errors?.['weakPassword']) {
-          <mat-error i18n="@@core.password-reset-form.error.password-toosimple">Password too short or too easily guessable</mat-error>
-        }
-      </div>
+        <div class="form-field">
+          <label for="newPassword" i18n="@@core.password-reset-form.newpassword">New Password</label>
+          <input
+            formControlName="newPassword"
+            id="newPassword"
+            name="newPassword"
+            type="password"
+          />
+          @if (passwordResetForm.controls.newPassword.errors?.['minlength']) {
+            <mat-error i18n="@@core.password-reset-form.error.password-tooshort">Password shorter
+              than {{ passwordResetForm.controls.newPassword.errors?.['minlength'].requiredLength }}
+            </mat-error>
+          }
+          @if (passwordResetForm.controls.newPassword.errors?.['weakPassword']) {
+            <mat-error i18n="@@core.password-reset-form.error.password-toosimple">Password too short or too easily guessable</mat-error>
+          }
+        </div>
 
-      <div class="form-field">
-        <label for="confirmedPassword" i18n="@@core.password-reset-form.confirmedpassword">Confirm Password</label>
-        <input
-          formControlName="confirmedPassword"
-          id="confirmedPassword"
-          name="confirmedPassword"
-          type="password"
-        />
-        @if (passwordResetForm.controls.confirmedPassword.errors?.['passwordMismatch']) {
-          <mat-error i18n="@@core.password-reset-form.error.need-match">Passwords need to match</mat-error>
-        }
-      </div>
+        <div class="form-field">
+          <label for="confirmedPassword" i18n="@@core.password-reset-form.confirmedpassword">Confirm Password</label>
+          <input
+            formControlName="confirmedPassword"
+            id="confirmedPassword"
+            name="confirmedPassword"
+            type="password"
+          />
+          @if (passwordResetForm.controls.confirmedPassword.errors?.['passwordMismatch']) {
+            <mat-error i18n="@@core.password-reset-form.error.need-match">Passwords need to match</mat-error>
+          }
+        </div>
 
-      <div class="buttons">
-        <button (click)="savePassword()"
-                [disabled]="passwordResetForm.invalid"
-                color="primary"
-                mat-flat-button
-                name="login">
-          <span i18n="@@core.password-reset-form.save">Save new password</span>
-        </button>
-      </div>
-
+        <div class="buttons">
+          <button (click)="savePassword()"
+                  [disabled]="passwordResetForm.invalid"
+                  color="primary"
+                  mat-flat-button
+                  name="login">
+            <span i18n="@@core.password-reset-form.save">Save new password</span>
+          </button>
+        </div>
+      }
       <div class="login-link">
         <a i18n="@@core.password-reset-form.return" routerLink="/login">Return to Login</a>
       </div>

--- a/projects/core/src/lib/pages/password-reset/password-reset.component.html
+++ b/projects/core/src/lib/pages/password-reset/password-reset.component.html
@@ -36,9 +36,7 @@
           type="password"
         />
         @if (passwordResetForm.controls.newPassword.errors?.['minlength']) {
-          <mat-error i18n="@@core.password-reset-form.error.password-tooshort">Password shorter
-            than {{ passwordResetForm.controls.newPassword.errors?.['minlength'].requiredLength }}
-          </mat-error>
+          <mat-error i18n="@@core.password-reset-form.error.password-tooshort">Password shorter than {{ passwordResetForm.controls.newPassword.errors?.['minlength'].requiredLength }}</mat-error>
         }
         @if (passwordResetForm.controls.newPassword.errors?.['weakPassword']) {
           <mat-error i18n="@@core.password-reset-form.error.password-toosimple">Password too short or too easily guessable</mat-error>

--- a/projects/core/src/lib/pages/password-reset/password-reset.component.html
+++ b/projects/core/src/lib/pages/password-reset/password-reset.component.html
@@ -3,7 +3,7 @@
   <div [formGroup]="passwordResetForm" class="password-reset-form">
 
     <div class="password-reset-form__header">
-      <div i18n="@@shared.password-reset-form.title">Reset Password</div>
+      <div i18n="@@core.password-reset-form.title">Reset Password</div>
       <mat-icon class="logo" svgIcon="logo"></mat-icon>
     </div>
 
@@ -14,7 +14,7 @@
       <p class="token-validity">Reset token is valid until {{ token.tokenValidUntil | date:'medium' }}</p>
 
       <div class="form-field">
-        <label for="username" i18n="@@shared.password-reset-form.username">Username</label>
+        <label for="username" i18n="@@core.password-reset-form.username">Username</label>
         <input
           [tmAutoFocus]="true"
           formControlName="username"
@@ -23,12 +23,12 @@
           type="text"
         />
         @if (passwordResetForm.controls.username.errors) {
-          <mat-error i18n="@@shared.password-reset-form.error.username-invalid">Username is invalid</mat-error>
+          <mat-error i18n="@@core.password-reset-form.error.username-invalid">Username is invalid</mat-error>
         }
       </div>
 
       <div class="form-field">
-        <label for="newPassword" i18n="@@shared.password-reset-form.newpassword">New Password</label>
+        <label for="newPassword" i18n="@@core.password-reset-form.newpassword">New Password</label>
         <input
           formControlName="newPassword"
           id="newPassword"
@@ -36,17 +36,17 @@
           type="password"
         />
         @if (passwordResetForm.controls.newPassword.errors?.['minlength']) {
-          <mat-error i18n="@@shared.password-reset-form.error.password-tooshort">Password shorter
+          <mat-error i18n="@@core.password-reset-form.error.password-tooshort">Password shorter
             than {{ passwordResetForm.controls.newPassword.errors?.['minlength'].requiredLength }}
           </mat-error>
         }
         @if (passwordResetForm.controls.newPassword.errors?.['weakPassword']) {
-          <mat-error i18n="@@shared.password-reset-form.error.password-toosimple">Password too short or too easily guessable</mat-error>
+          <mat-error i18n="@@core.password-reset-form.error.password-toosimple">Password too short or too easily guessable</mat-error>
         }
       </div>
 
       <div class="form-field">
-        <label for="confirmedPassword" i18n="@@shared.password-reset-form.confirmedpassword">Confirm Password</label>
+        <label for="confirmedPassword" i18n="@@core.password-reset-form.confirmedpassword">Confirm Password</label>
         <input
           formControlName="confirmedPassword"
           id="confirmedPassword"
@@ -54,7 +54,7 @@
           type="password"
         />
         @if (passwordResetForm.controls.confirmedPassword.errors?.['passwordMismatch']) {
-          <mat-error i18n="@@shared.password-reset-form.error.need-match">Passwords need to match</mat-error>
+          <mat-error i18n="@@core.password-reset-form.error.need-match">Passwords need to match</mat-error>
         }
       </div>
 
@@ -64,12 +64,12 @@
                 color="primary"
                 mat-flat-button
                 name="login">
-          <span i18n="@@shared.password-reset-form.save">Save new password</span>
+          <span i18n="@@core.password-reset-form.save">Save new password</span>
         </button>
       </div>
 
       <div class="login-link">
-        <a i18n="@@shared.password-reset-form.return" routerLink="/login">Return to Login</a>
+        <a i18n="@@core.password-reset-form.return" routerLink="/login">Return to Login</a>
       </div>
 
     </div>

--- a/projects/core/src/lib/pages/password-reset/password-reset.component.spec.ts
+++ b/projects/core/src/lib/pages/password-reset/password-reset.component.spec.ts
@@ -1,11 +1,19 @@
 import { render, screen } from '@testing-library/angular';
 import { PasswordResetComponent } from './password-reset.component';
+import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import { ReactiveFormsModule } from '@angular/forms';
+import { AutoFocusDirective } from '@tailormap-viewer/shared';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 
 describe('PasswordResetComponent', () => {
 
   test('should render', async () => {
-    await render(PasswordResetComponent);
-    expect(screen.getByText('password-reset works!'));
+    await render(PasswordResetComponent, {
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
+      imports: [ReactiveFormsModule, HttpClientTestingModule],
+      declarations: [AutoFocusDirective],
+    });
+    expect(screen.getByText('Username')).toBeInTheDocument();
   });
 
 });

--- a/projects/core/src/lib/pages/password-reset/password-reset.component.spec.ts
+++ b/projects/core/src/lib/pages/password-reset/password-reset.component.spec.ts
@@ -13,7 +13,7 @@ describe('PasswordResetComponent', () => {
       imports: [ ReactiveFormsModule, HttpClientTestingModule ],
       declarations: [AutoFocusDirective],
     });
-    expect(screen.getByText('Username')).toBeInTheDocument();
+    expect(screen.getByText('Reset Password')).toBeInTheDocument();
   });
 
 });

--- a/projects/core/src/lib/pages/password-reset/password-reset.component.spec.ts
+++ b/projects/core/src/lib/pages/password-reset/password-reset.component.spec.ts
@@ -10,7 +10,7 @@ describe('PasswordResetComponent', () => {
   test('should render', async () => {
     await render(PasswordResetComponent, {
       schemas: [CUSTOM_ELEMENTS_SCHEMA],
-      imports: [ReactiveFormsModule, HttpClientTestingModule],
+      imports: [ ReactiveFormsModule, HttpClientTestingModule ],
       declarations: [AutoFocusDirective],
     });
     expect(screen.getByText('Username')).toBeInTheDocument();

--- a/projects/core/src/lib/pages/password-reset/password-reset.component.spec.ts
+++ b/projects/core/src/lib/pages/password-reset/password-reset.component.spec.ts
@@ -1,0 +1,11 @@
+import { render, screen } from '@testing-library/angular';
+import { PasswordResetComponent } from './password-reset.component';
+
+describe('PasswordResetComponent', () => {
+
+  test('should render', async () => {
+    await render(PasswordResetComponent);
+    expect(screen.getByText('password-reset works!'));
+  });
+
+});

--- a/projects/core/src/lib/pages/password-reset/password-reset.component.ts
+++ b/projects/core/src/lib/pages/password-reset/password-reset.component.ts
@@ -11,7 +11,7 @@ interface Token {
 @Component({
   selector: 'tm-password-reset',
   templateUrl: './password-reset.component.html',
-  styleUrls: [ './password-reset.component.css' ],
+  styleUrls: ['./password-reset.component.css'],
   changeDetection: ChangeDetectionStrategy.OnPush,
   standalone: false,
 })
@@ -35,7 +35,7 @@ export class PasswordResetComponent implements OnInit {
     newPassword: new FormControl<string>('', {
       nonNullable: true,
       validators: [ Validators.required, Validators.minLength(PasswordResetComponent.minPasswordLength) ],
-      asyncValidators: [ this.passwordStrengthValidator() ],
+      asyncValidators: [this.passwordStrengthValidator()],
     }),
 
     confirmedPassword: new FormControl<string>('', {
@@ -69,15 +69,18 @@ export class PasswordResetComponent implements OnInit {
           next: (result) => {
             if (result) {
               this.errorMessageSubject.next('');
-              this.infoMessageSubject.next($localize`:@@core.password-reset-form.succes:Password successfully reset, you can now log in with your new password.`);
+              this.infoMessageSubject.next(
+                $localize`:@@core.password-reset-form.succes:Password successfully reset, you can now log in with your new password.`);
             } else {
               this.infoMessageSubject.next('');
-              this.errorMessageSubject.next($localize`:@@core.password-reset-form.error-saving:Error saving password, please check your token, username and password and try again.`);
+              this.errorMessageSubject.next(
+                $localize`:@@core.password-reset-form.error-saving:Error saving password, please check your token, username and password and try again.`);
             }
             this.passwordResetForm.reset();
           }, error: (error) => {
             this.infoMessageSubject.next('');
-            this.errorMessageSubject.next($localize`:@@core.password-reset-form.error-reset:Error resetting password: ${(error?.error?.message || error?.message || error.toString())}`);
+            this.errorMessageSubject.next(
+              $localize`:@@core.password-reset-form.error-reset:Error resetting password: ${(error?.error?.message || error?.message || error.toString())}`);
             this.passwordResetForm.reset();
           },
         });

--- a/projects/core/src/lib/pages/password-reset/password-reset.component.ts
+++ b/projects/core/src/lib/pages/password-reset/password-reset.component.ts
@@ -70,7 +70,7 @@ export class PasswordResetComponent implements OnInit {
             if (result) {
               this.errorMessageSubject.next('');
               this.infoMessageSubject.next(
-                $localize`:@@core.password-reset-form.succes:Password successfully reset, you can now log in with your new password.`);
+                $localize`:@@core.password-reset-form.success:Password successfully reset, you can now log in with your new password.`);
             } else {
               this.infoMessageSubject.next('');
               this.errorMessageSubject.next(

--- a/projects/core/src/lib/pages/password-reset/password-reset.component.ts
+++ b/projects/core/src/lib/pages/password-reset/password-reset.component.ts
@@ -69,15 +69,15 @@ export class PasswordResetComponent implements OnInit {
           next: (result) => {
             if (result) {
               this.errorMessageSubject.next('');
-              this.infoMessageSubject.next($localize`:@@shared.password-reset-form.succes:Password successfully reset, you can now log in with your new password.`);
+              this.infoMessageSubject.next($localize`:@@core.password-reset-form.succes:Password successfully reset, you can now log in with your new password.`);
             } else {
               this.infoMessageSubject.next('');
-              this.errorMessageSubject.next($localize`:@@shared.password-reset-form.error-saving:Error saving password, please check your token, username and password and try again.`);
+              this.errorMessageSubject.next($localize`:@@core.password-reset-form.error-saving:Error saving password, please check your token, username and password and try again.`);
             }
             this.passwordResetForm.reset();
           }, error: (error) => {
             this.infoMessageSubject.next('');
-            this.errorMessageSubject.next($localize`:@@shared.password-reset-form.error-reset:Error resetting password: ${(error?.error?.message || error?.message || error.toString())}`);
+            this.errorMessageSubject.next($localize`:@@core.password-reset-form.error-reset:Error resetting password: ${(error?.error?.message || error?.message || error.toString())}`);
             this.passwordResetForm.reset();
           },
         });
@@ -87,7 +87,7 @@ export class PasswordResetComponent implements OnInit {
   protected tokenIsValid(): boolean {
     const isValid = !!(this.token.uuid && this.token.uuid.length > 0 && this.token.tokenValidUntil && this.token.tokenValidUntil > new Date());
     if (!isValid) {
-      this.errorMessageSubject.next($localize`:@@shared.password-reset-form.error.token-expired:Your password reset token is invalid or has expired.`);
+      this.errorMessageSubject.next($localize`:@@core.password-reset-form.error.token-expired:Your password reset token is invalid or has expired.`);
     }
     return isValid;
   }

--- a/projects/core/src/lib/pages/password-reset/password-reset.component.ts
+++ b/projects/core/src/lib/pages/password-reset/password-reset.component.ts
@@ -1,0 +1,105 @@
+import { ChangeDetectionStrategy, Component, inject, OnInit } from '@angular/core';
+import { BehaviorSubject, map, Observable, of } from 'rxjs';
+import { AbstractControl, AsyncValidatorFn, FormBuilder, FormControl, ValidationErrors, Validators } from '@angular/forms';
+import { TailormapSecurityApiV1Service, ValidatorsHelper } from '@tailormap-viewer/api';
+
+interface Token {
+  uuid: string;
+  tokenValidUntil: Date | null;
+}
+
+@Component({
+  selector: 'tm-password-reset',
+  templateUrl: './password-reset.component.html',
+  styleUrls: [ './password-reset.component.css' ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  standalone: false,
+})
+export class PasswordResetComponent implements OnInit {
+  private static minPasswordLength = 8;
+  public token: Token = {
+    uuid: '', tokenValidUntil: null,
+  };
+  private securityApiService = inject(TailormapSecurityApiV1Service);
+  private errorMessageSubject = new BehaviorSubject('');
+  public errorMessage$ = this.errorMessageSubject.asObservable();
+  private infoMessageSubject = new BehaviorSubject('');
+  public infoMessage$ = this.infoMessageSubject.asObservable();
+
+  private formBuilder = inject(FormBuilder);
+  public passwordResetForm = this.formBuilder.group({
+    username: new FormControl<string>('', {
+      nonNullable: true, validators: [ Validators.required, Validators.pattern(ValidatorsHelper.NAME_REGEX) ],
+    }),
+
+    newPassword: new FormControl<string>('', {
+      nonNullable: true,
+      validators: [ Validators.required, Validators.minLength(PasswordResetComponent.minPasswordLength) ],
+      asyncValidators: [ this.passwordStrengthValidator() ],
+    }),
+
+    confirmedPassword: new FormControl<string>('', {
+      nonNullable: true, validators: [ Validators.required, (control: AbstractControl) => {
+        if (!control?.value) return null;
+        if (this.passwordResetForm?.value?.newPassword !== control.value) {
+          return { passwordMismatch: true };
+        }
+        return null;
+      } ],
+    }),
+
+  });
+
+  public ngOnInit(): void {
+    // token is a base64 encoded string with uuid#validUntil
+    // validUntil is a number representing seconds since epoch
+    // example: a3f5c8e2-9f3b-4c6d-8e2a-9f3b4c6d8e2a#1760013815
+    // base64 encoded: YTNmNWM4ZTItOWYzYi00YzZkLThlMmEtOWYzYjRjNmQ4ZTJhIzIwMjQtMTItMzFUMjM6NTk6NTkuOTk5Wg==
+    const tokenString = atob(decodeURIComponent(window.location.href.split('/').pop() || ''));
+    this.token.uuid = tokenString.split('#')[0] || '';
+    this.token.tokenValidUntil = tokenString.split('#')[1] ? new Date(Number(tokenString.split('#')[1]) * 1000) : null;
+    this.tokenIsValid();
+  }
+
+  public savePassword() {
+    if (this.passwordResetForm.valid && this.tokenIsValid()) {
+      // send token, username and new password to backend
+      this.securityApiService.resetPassword$(this.token.uuid, this.passwordResetForm.value.username ?? '', this.passwordResetForm.value.newPassword ?? '')
+        .subscribe({
+          next: (result) => {
+            if (result) {
+              this.errorMessageSubject.next('');
+              this.infoMessageSubject.next($localize`:@@shared.password-reset-form.succes:Password successfully reset, you can now log in with your new password.`);
+            } else {
+              this.infoMessageSubject.next('');
+              this.errorMessageSubject.next($localize`:@@shared.password-reset-form.error-saving:Error saving password, please check your token, username and password and try again.`);
+            }
+            this.passwordResetForm.reset();
+          }, error: (error) => {
+            this.infoMessageSubject.next('');
+            this.errorMessageSubject.next($localize`:@@shared.password-reset-form.error-reset:Error resetting password: ${(error?.error?.message || error?.message || error.toString())}`);
+            this.passwordResetForm.reset();
+          },
+        });
+    }
+  }
+
+  protected tokenIsValid(): boolean {
+    const isValid = !!(this.token.uuid && this.token.uuid.length > 0 && this.token.tokenValidUntil && this.token.tokenValidUntil > new Date());
+    if (!isValid) {
+      this.errorMessageSubject.next($localize`:@@shared.password-reset-form.error.token-expired:Your password reset token is invalid or has expired.`);
+    }
+    return isValid;
+  }
+
+  private passwordStrengthValidator(): AsyncValidatorFn {
+    return (control: AbstractControl): Observable<ValidationErrors | null> => {
+      if (!control.value || control.value < PasswordResetComponent.minPasswordLength) {
+        return of(null);
+      }
+      return this.securityApiService.validatePasswordStrength$(control.value).pipe(map((result: boolean) => {
+        return result ? null : { weakPassword: true };
+      }));
+    };
+  }
+}

--- a/projects/core/src/lib/pages/password-reset/password-reset.component.ts
+++ b/projects/core/src/lib/pages/password-reset/password-reset.component.ts
@@ -97,7 +97,7 @@ export class PasswordResetComponent implements OnInit {
 
   private passwordStrengthValidator(): AsyncValidatorFn {
     return (control: AbstractControl): Observable<ValidationErrors | null> => {
-      if (!control.value || control.value < PasswordResetComponent.minPasswordLength) {
+      if (!control.value || control.value.length < PasswordResetComponent.minPasswordLength) {
         return of(null);
       }
       return this.securityApiService.validatePasswordStrength$(control.value).pipe(map((result: boolean) => {


### PR DESCRIPTION
[![HTM-1649](https://badgen.net/badge/JIRA/HTM-1649/pink?icon=jira)](https://b3partners.atlassian.net/browse/HTM-1649) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=Tailormap&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Also includes refactoring:
- [x] HTM-1690: Refactor tailormap-viewer: for the move of /validate-password
- [x] Move NAME_REGEX to common API so it can be used in the viewer and the admin

requires https://github.com/Tailormap/tailormap-api/pull/1373


[HTM-1649]: https://b3partners.atlassian.net/browse/HTM-1649?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ