### PR TITLE
HTM-1815: Move error message component outside the template

### DIFF
--- a/projects/core/src/lib/pages/login/login-form/login-form.component.html
+++ b/projects/core/src/lib/pages/login/login-form/login-form.component.html
@@ -6,6 +6,9 @@
       <div i18n="@@shared.login-form.title">Login</div>
       <mat-icon class="logo" svgIcon="logo"></mat-icon>
     </div>
+
+    <tm-error-message [message]="(errorMessage$ | async) ?? ''"></tm-error-message>
+
     @if (hasSSOButtons) {
       <div class="login-form__sso">
         <div class="section-title" i18n="@@shared.login-form.sso-title">Login with your organisation</div>
@@ -46,7 +49,6 @@
 
     <ng-template #loginFormTemplate>
       <div class="login-form__body">
-        <tm-error-message [message]="(errorMessage$ | async) ?? ''"></tm-error-message>
         <div class="form-field">
           <label for="login_username" i18n="@@shared.login-form.username">Username</label>
           <input id="login_username"


### PR DESCRIPTION
[![HTM-1815](https://img.shields.io/badge/JIRA-HTM--1815-7A54FF?logo=jira)](https://b3partners.atlassian.net/browse/HTM-1815) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=Tailormap&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Move error message component outside the `#loginFormTemplate` so it will show even when the local login form is collapsed

[HTM-1815]: https://b3partners.atlassian.net/browse/HTM-1815?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ