### PR TITLE
Revert "Bump uuid from 11.1.0 to 14.0.0"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
         "rxjs": "^7.8.2",
         "svg2pdf.js": "^2.7.0",
         "tslib": "^2.8.1",
-        "uuid": "^14.0.0",
+        "uuid": "^11.1.0",
         "zone.js": "^0.15.1"
       },
       "devDependencies": {
@@ -22489,16 +22489,16 @@
       }
     },
     "node_modules/uuid": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
-      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist-node/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/uzip-module": {

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "rxjs": "^7.8.2",
     "svg2pdf.js": "^2.7.0",
     "tslib": "^2.8.1",
-    "uuid": "^14.0.0",
+    "uuid": "^11.1.0",
     "zone.js": "^0.15.1"
   },
   "devDependencies": {


### PR DESCRIPTION
This reverts commit a68497b6f76a1172bd4c0c439e05e5da7beaf5e8.

Leads to Jest errors:

```
  ● Test suite failed to run

    Jest encountered an unexpected token

    Jest failed to parse a file. This happens e.g. when your code or its dependencies use non-standard JavaScript syntax, or when Jest is not configured to support such syntax.

    Out of the box Jest supports Babel, which will be used to transform your files into valid JS based on your Babel configuration.

    By default "node_modules" folder is ignored by transformers.

    Here's what you can do:
     • If you are trying to use ECMAScript Modules, see https://jestjs.io/docs/ecmascript-modules for how to enable it.
     • If you are trying to use TypeScript, see https://jestjs.io/docs/getting-started#using-typescript
     • To have some of your "node_modules" files transformed, you can specify a custom "transformIgnorePatterns" in your config.
     • If you need a custom transformation specify a "transform" option in your config.
     • If you simply want to mock your non-JS modules (e.g. binary assets) you can stub them out with the "moduleNameMapper" config option.

    You'll find more details and examples of these config options in the docs:
    https://jestjs.io/docs/configuration
    For information about custom transformations, see:
    https://jestjs.io/docs/code-transformation

    Details:

    /home/runner/work/tailormap-viewer/tailormap-viewer/node_modules/uuid/dist/index.js:1
    ({"Object.<anonymous>":function(module,exports,require,__dirname,__filename,jest){export { default as MAX } from './max.js';
                                                                                      ^^^^^^

    SyntaxError: Unexpected token 'export'

       6 | } from '../models/drawing-feature.model';
       7 | import { DrawingToolEvent, MapStyleModel } from '@tailormap-viewer/map';
    >  8 | import { v4 as uuidv4 } from 'uuid';
         | ^
       9 | import { ApplicationStyleService } from '../../services/application-style.service';
      10 | import { TailormapApiConstants } from '@tailormap-viewer/api';
      11 |

      at Runtime.createScriptFromCode (../../node_modules/jest-runtime/build/index.js:1505:14)
      at Object.require (src/lib/map/helpers/drawing.helper.ts:8:1)
      at Object.require (src/lib/map/index.ts:3:1)
      at Object.require (src/lib/components/attribute-list/state/attribute-list.selectors.ts:10:1)
      at Object.require (src/lib/services/application-bookmark/application-bookmark.service.ts:21:1)
      at Object.require (src/lib/services/viewer-layout/mobile-layout.service.ts:5:1)
      at Object.require (src/lib/components/menubar/menubar.service.ts:5:1)
      at Object.require (src/lib/components/menubar/index.ts:1:1)
      at Object.<anonymous> (src/lib/components/toolbar/coordinate-link-window/coordinate-link-window-menu-button/coordinate-link-window-menu-button.component.spec.ts:4:1)

```