### PR TITLE
HTM-1998: Add tooltip to close button of menubar panel

### DIFF
--- a/projects/core/src/lib/shared/components/dialog/dialog.component.html
+++ b/projects/core/src/lib/shared/components/dialog/dialog.component.html
@@ -30,7 +30,7 @@
           }
         </button>
       }
-      <button mat-icon-button class="close-button" (click)="close()">
+      <button mat-icon-button class="close-button" (click)="close()" tmTooltip="Close panel" i18n-tmTooltip="@@core.common.close">
         <mat-icon svgIcon="close"></mat-icon>
       </button>
     </div>


### PR DESCRIPTION
[![HTM-1998](https://badgen.net/badge/JIRA/HTM-1998/7A54FF?icon=jira)](https://b3partners.atlassian.net/browse/HTM-1998) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=Tailormap&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

The tmTooltip directive also adds the text as the aria-label 

[HTM-1998]: https://b3partners.atlassian.net/browse/HTM-1998?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ