### PR TITLE
HTM-2002: Use darker shade of red for app-warn palette

### DIFF
--- a/projects/core/assets/custom-theme.scss
+++ b/projects/core/assets/custom-theme.scss
@@ -86,7 +86,7 @@ $tailormap-app-primary: mat.m2-define-palette($mat-tailormap-primary);
 $tailormap-app-accent:  mat.m2-define-palette($mat-tailormap-accent);
 
 // The warn palette is optional (defaults to red).
-$app-warn: mat.m2-define-palette(mat.$m2-red-palette);
+$app-warn: mat.m2-define-palette(mat.$m2-red-palette, 700, 100, 900);
 
 // Create the theme object. A theme consists of configurations for individual
 // theming systems such as "color" or "typography".


### PR DESCRIPTION
[![HTM-2002](https://badgen.net/badge/JIRA/HTM-2002/7A54FF?icon=jira)](https://b3partners.atlassian.net/browse/HTM-2002) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=Tailormap&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

In order to comply to WCAG contrast guidelines 

[HTM-2002]: https://b3partners.atlassian.net/browse/HTM-2002?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ