### PR TITLE
HTM-2009: Add aria attributes to attribute list table

### DIFF
--- a/projects/core/assets/locale/messages.core.de.xlf
+++ b/projects/core/assets/locale/messages.core.de.xlf
@@ -2,9 +2,9 @@
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
   <file source-language="en-US" target-language="de" datatype="plaintext" original="ng2.template">
     <body>
-      <trans-unit id="core.attribute-list.attribute-list-table" datatype="html">
-        <source>Attribute list table</source>
-        <target>Attributliste Tabelle</target>
+      <trans-unit id="core.attribute-list.attribute-list" datatype="html">
+        <source>Attribute list</source>
+        <target>Attributlisten</target>
       </trans-unit>
       <trans-unit id="core.attribute-list.clear-all-filters" datatype="html">
         <source>Clear all filters</source>

--- a/projects/core/assets/locale/messages.core.de.xlf
+++ b/projects/core/assets/locale/messages.core.de.xlf
@@ -2,6 +2,10 @@
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
   <file source-language="en-US" target-language="de" datatype="plaintext" original="ng2.template">
     <body>
+      <trans-unit id="core.attribute-list.attribute-list-table" datatype="html">
+        <source>Attribute list table</source>
+        <target>Attributliste Tabelle</target>
+      </trans-unit>
       <trans-unit id="core.attribute-list.clear-all-filters" datatype="html">
         <source>Clear all filters</source>
         <target>Alle Filter löschen</target>

--- a/projects/core/assets/locale/messages.core.en.xlf
+++ b/projects/core/assets/locale/messages.core.en.xlf
@@ -2,8 +2,8 @@
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
   <file source-language="en" datatype="plaintext" original="ng2.template">
     <body>
-      <trans-unit id="core.attribute-list.attribute-list-table" datatype="html">
-        <source>Attribute list table</source>
+      <trans-unit id="core.attribute-list.attribute-list" datatype="html">
+        <source>Attribute list</source>
       </trans-unit>
       <trans-unit id="core.attribute-list.clear-all-filters" datatype="html">
         <source>Clear all filters</source>

--- a/projects/core/assets/locale/messages.core.en.xlf
+++ b/projects/core/assets/locale/messages.core.en.xlf
@@ -2,6 +2,9 @@
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
   <file source-language="en" datatype="plaintext" original="ng2.template">
     <body>
+      <trans-unit id="core.attribute-list.attribute-list-table" datatype="html">
+        <source>Attribute list table</source>
+      </trans-unit>
       <trans-unit id="core.attribute-list.clear-all-filters" datatype="html">
         <source>Clear all filters</source>
       </trans-unit>

--- a/projects/core/assets/locale/messages.core.nl.xlf
+++ b/projects/core/assets/locale/messages.core.nl.xlf
@@ -2,6 +2,10 @@
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
   <file source-language="en-US" target-language="nl" datatype="plaintext" original="ng2.template">
     <body>
+      <trans-unit id="core.attribute-list.attribute-list-table" datatype="html">
+        <source>Attribute list table</source>
+        <target>Attributenlijst tabel</target>
+      </trans-unit>
       <trans-unit id="core.attribute-list.clear-all-filters" datatype="html">
         <source>Clear all filters</source>
         <target>Alle filters wissen</target>

--- a/projects/core/assets/locale/messages.core.nl.xlf
+++ b/projects/core/assets/locale/messages.core.nl.xlf
@@ -2,9 +2,9 @@
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
   <file source-language="en-US" target-language="nl" datatype="plaintext" original="ng2.template">
     <body>
-      <trans-unit id="core.attribute-list.attribute-list-table" datatype="html">
-        <source>Attribute list table</source>
-        <target>Attributenlijst tabel</target>
+      <trans-unit id="core.attribute-list.attribute-list" datatype="html">
+        <source>Attribute list</source>
+        <target>Attributenlijst</target>
       </trans-unit>
       <trans-unit id="core.attribute-list.clear-all-filters" datatype="html">
         <source>Clear all filters</source>

--- a/projects/core/src/lib/components/attribute-list/attribute-list-content/attribute-list-content.component.html
+++ b/projects/core/src/lib/components/attribute-list/attribute-list-content/attribute-list-content.component.html
@@ -13,7 +13,6 @@
 
   @if (hasRows$ | async) {
     <tm-attribute-list-table
-      role="table"
       [rows]="rows$ | async"
       [columns]="columns$ | async"
       [sort]="sort$ | async"
@@ -24,6 +23,7 @@
       [loadingFeatureDetailsIds]="loadingFeatureDetailsIds$ | async"
       [showStatistics]="showStatistics$ | async"
       [statistics]="statistics$ | async"
+      [pagingDataSelectedTab]="pagingDataSelectedTab$ | async"
       (selectRow)="onSelectRow($event)"
       (setSort)="onSortClick($event)"
       (setFilter)="onSetFilter($event)"

--- a/projects/core/src/lib/components/attribute-list/attribute-list-content/attribute-list-content.component.ts
+++ b/projects/core/src/lib/components/attribute-list/attribute-list-content/attribute-list-content.component.ts
@@ -6,7 +6,7 @@ import { Store } from '@ngrx/store';
 import { AttributeListColumnModel } from '../models/attribute-list-column.model';
 import {
   selectColumnsForSelectedTab, selectDataForSelectedTab, selectHasNoRowsForSelectedTab, selectLoadErrorForSelectedTab,
-  selectLoadingDataSelectedTab,
+  selectLoadingDataSelectedTab, selectPagingDataSelectedTab,
   selectRowCountForSelectedTab,
   selectRowsForSelectedTab, selectSelectedRowIdForSelectedTab, selectSelectedTab, selectSortForSelectedTab,
 } from '../state/attribute-list.selectors';
@@ -24,6 +24,7 @@ import { MatSnackBar } from '@angular/material/snack-bar';
 import { StatisticsHelper } from '../helpers/statistics-helper';
 import { StatisticType } from '../models/attribute-list-api-service.model';
 import { AttributeListStatisticsService } from '../services/attribute-list-statistics.service';
+import { AttributeListPagingDataType } from '../models/attribute-list-paging-data.type';
 
 @Component({
   selector: 'tm-attribute-list-content',
@@ -50,6 +51,7 @@ export class AttributeListContentComponent implements OnInit {
   public errorMessage$: Observable<string | undefined> = of(undefined);
   public hasRows$: Observable<boolean> = of(false);
   public hasNoRows$: Observable<boolean> = of(true);
+  public pagingDataSelectedTab$: Observable<AttributeListPagingDataType> = this.store$.select(selectPagingDataSelectedTab);
 
   public canExpandRows$ = this.attributeListFeatureDetailsService.canExpandRows$;
   public featureDetails$ = this.attributeListFeatureDetailsService.featureDetails$;

--- a/projects/core/src/lib/components/attribute-list/attribute-list-table/attribute-list-table.component.html
+++ b/projects/core/src/lib/components/attribute-list/attribute-list-table/attribute-list-table.component.html
@@ -18,9 +18,10 @@
 <mat-table [dataSource]="rows"
   [trackBy]="trackByRowId"
   multiTemplateDataRows
-  aria-label="Attribute List Table"
+  aria-label="Attribute list table"
   i18n-aria-label="@@core.attribute-list.attribute-list-table"
-  [attr.aria-colcount]="columns()?.length">
+  [attr.aria-colcount]="columns()?.length"
+  [attr.aria-rowcount]="pagingDataSelectedTab()?.totalCount">
 
   <ng-container [matColumnDef]="EXPAND_DETAILS_COLUMN_NAME">
     <mat-header-cell class="column_small" *matHeaderCellDef></mat-header-cell>
@@ -51,8 +52,7 @@
         (click)="onSortClick(col.id)"
         [style.flexBasis]="getColumnWidth(col)"
         [attr.aria-sort]="getAriaSortValue(col.id)"
-        [attr.aria-colindex]="$index + 1"
-        [attr.aria-rowcount]="pagingDataSelectedTab()?.totalCount">
+        [attr.aria-colindex]="$index + 1">
         <span [title]="col.label">{{col.label}}</span>
         @if (setFilter) {
           <mat-icon

--- a/projects/core/src/lib/components/attribute-list/attribute-list-table/attribute-list-table.component.html
+++ b/projects/core/src/lib/components/attribute-list/attribute-list-table/attribute-list-table.component.html
@@ -51,7 +51,8 @@
         (click)="onSortClick(col.id)"
         [style.flexBasis]="getColumnWidth(col)"
         [attr.aria-sort]="getAriaSortValue(col.id)"
-        [attr.aria-colindex]="$index">
+        [attr.aria-colindex]="$index + 1"
+        [attr.aria-rowcount]="pagingDataSelectedTab()?.totalCount">
         <span [title]="col.label">{{col.label}}</span>
         @if (setFilter) {
           <mat-icon
@@ -69,7 +70,10 @@
           (positionChanged)="columnWidthChanged($event, col)"
         orientation="vertical"></tm-panel-resize>
       </mat-header-cell>
-      <mat-cell *matCellDef="let currRow" [style.flexBasis]="getColumnWidth(col)" [attr.aria-colindex]="$index">
+      <mat-cell *matCellDef="let currRow"
+                [style.flexBasis]="getColumnWidth(col)"
+                [attr.aria-colindex]="$index + 1"
+                [attr.aria-rowindex]="rowIndexMap().get(currRow.id)">
         <div class="cell-content"
         [title]="currRow.attributes[col.id]">{{currRow.attributes[col.id]}}</div>
       </mat-cell>
@@ -116,7 +120,8 @@
   <mat-row *matRowDef="let row; let dataIndex = dataIndex; columns: colNames;"
     (click)="onRowClick($event, row);"
     [class.even_row]="dataIndex % 2 === 1"
-    [class.selected_row]="isSelected(row)"></mat-row>
+    [class.selected_row]="isSelected(row)"
+    [attr.aria-rowindex]="rowIndexMap().get(row.id)"></mat-row>
 
   <mat-row *matRowDef="let row; columns: [EXPAND_DETAILS_ROW_NAME]" class="details-row"
            [ngClass]="expandedRowsIds.has(row.id) ? 'expanded' : 'collapsed'"></mat-row>

--- a/projects/core/src/lib/components/attribute-list/attribute-list-table/attribute-list-table.component.html
+++ b/projects/core/src/lib/components/attribute-list/attribute-list-table/attribute-list-table.component.html
@@ -50,7 +50,8 @@
         [class.header-cell--with-filter]="setFilter"
         (click)="onSortClick(col.id)"
         [style.flexBasis]="getColumnWidth(col)"
-        [attr.aria-sort]="getAriaSortValue(col.id)">
+        [attr.aria-sort]="getAriaSortValue(col.id)"
+        [attr.aria-colindex]="$index">
         <span [title]="col.label">{{col.label}}</span>
         @if (setFilter) {
           <mat-icon
@@ -68,7 +69,7 @@
           (positionChanged)="columnWidthChanged($event, col)"
         orientation="vertical"></tm-panel-resize>
       </mat-header-cell>
-      <mat-cell *matCellDef="let currRow" [style.flexBasis]="getColumnWidth(col)">
+      <mat-cell *matCellDef="let currRow" [style.flexBasis]="getColumnWidth(col)" [attr.aria-colindex]="$index">
         <div class="cell-content"
         [title]="currRow.attributes[col.id]">{{currRow.attributes[col.id]}}</div>
       </mat-cell>

--- a/projects/core/src/lib/components/attribute-list/attribute-list-table/attribute-list-table.component.html
+++ b/projects/core/src/lib/components/attribute-list/attribute-list-table/attribute-list-table.component.html
@@ -17,7 +17,10 @@
 
 <mat-table [dataSource]="rows"
   [trackBy]="trackByRowId"
-  multiTemplateDataRows>
+  multiTemplateDataRows
+  aria-label="Attribute List Table"
+  i18n-aria-label="@@core.attribute-list.attribute-list-table"
+  [attr.aria-colcount]="columns()?.length">
 
   <ng-container [matColumnDef]="EXPAND_DETAILS_COLUMN_NAME">
     <mat-header-cell class="column_small" *matHeaderCellDef></mat-header-cell>
@@ -46,7 +49,8 @@
         class="header-cell--with-resizer header-cell--with-sort"
         [class.header-cell--with-filter]="setFilter"
         (click)="onSortClick(col.id)"
-        [style.flexBasis]="getColumnWidth(col)">
+        [style.flexBasis]="getColumnWidth(col)"
+        [attr.aria-sort]="getAriaSortValue(col.id)">
         <span [title]="col.label">{{col.label}}</span>
         @if (setFilter) {
           <mat-icon

--- a/projects/core/src/lib/components/attribute-list/attribute-list-table/attribute-list-table.component.html
+++ b/projects/core/src/lib/components/attribute-list/attribute-list-table/attribute-list-table.component.html
@@ -18,8 +18,8 @@
 <mat-table [dataSource]="rows"
   [trackBy]="trackByRowId"
   multiTemplateDataRows
-  aria-label="Attribute list table"
-  i18n-aria-label="@@core.attribute-list.attribute-list-table"
+  aria-label="Attribute list"
+  i18n-aria-label="@@core.attribute-list.attribute-list"
   [attr.aria-colcount]="columns()?.length"
   [attr.aria-rowcount]="pagingDataSelectedTab()?.totalCount">
 

--- a/projects/core/src/lib/components/attribute-list/attribute-list-table/attribute-list-table.component.ts
+++ b/projects/core/src/lib/components/attribute-list/attribute-list-table/attribute-list-table.component.ts
@@ -6,6 +6,7 @@ import { AttributeFilterModel } from '@tailormap-viewer/api';
 import { FeatureDetailsModel, StatisticType } from '../models/attribute-list-api-service.model';
 import { StatisticsHelper } from '../helpers/statistics-helper';
 import { AttributeListStatisticColumnModel, StatisticValueModel } from '../models/attribute-list-statistic-column.model';
+import { AttributeListPagingDataType } from '../models/attribute-list-paging-data.type';
 
 const DEFAULT_COLUMN_WIDTH = 170;
 
@@ -53,6 +54,7 @@ export class AttributeListTableComponent {
 
   public showStatistics = input<boolean | null>(false);
   public statistics = input<AttributeListStatisticColumnModel[] | null>([]);
+  public pagingDataSelectedTab = input<AttributeListPagingDataType | null>(null);
 
   @Output()
   public selectRow = new EventEmitter<{ id: string; selected: boolean }>();
@@ -101,6 +103,16 @@ export class AttributeListTableComponent {
         return [ s.columnName, value ];
       },
     ));
+  });
+
+  public rowIndexMap = computed(() => {
+    const paging = this.pagingDataSelectedTab();
+    const pageOffset = paging ? (paging.pageIndex - 1) * paging.pageSize : 0;
+    const rowIndexMap = new Map<string, number>();
+    this._rows.forEach((row, index) => {
+      rowIndexMap.set(row.id, pageOffset + index + 1);
+    });
+    return rowIndexMap;
   });
 
   constructor() {

--- a/projects/core/src/lib/components/attribute-list/attribute-list-table/attribute-list-table.component.ts
+++ b/projects/core/src/lib/components/attribute-list/attribute-list-table/attribute-list-table.component.ts
@@ -219,4 +219,11 @@ export class AttributeListTableComponent {
     this.loadStatisticsForColumn.emit({ type, columnName: col.id, dataType: col.type });
   }
 
+  public getAriaSortValue(columnId: string): 'ascending' | 'descending' | 'none' {
+    if (!this.sort || this.sort.column !== columnId || this.sort.direction === '') {
+      return 'none';
+    }
+    return this.sort.direction === 'asc' ? 'ascending' : 'descending';
+  }
+
 }


### PR DESCRIPTION
[![HTM-2009](https://badgen.net/badge/JIRA/HTM-2009/7A54FF?icon=jira)](https://b3partners.atlassian.net/browse/HTM-2009) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=Tailormap&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

Aria attributes are added that are needed for accessibility according to [Mozilla's ARIA table documentation](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/table_role) 

[HTM-2009]: https://b3partners.atlassian.net/browse/HTM-2009?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ