### PR TITLE
HTM-2020: Use darker shade of red for error color

### DIFF
--- a/projects/core/assets/tailormap-styles.css
+++ b/projects/core/assets/tailormap-styles.css
@@ -81,7 +81,7 @@
   --palette-accent-contrast-A700: var(--dark-primary-text);
 
   --primary-color: rgb(98, 54, 255);
-  --error-color: #ff3636;
+  --error-color: #df2e2e;
   --info-color: rgb(14, 59, 68);
   --info-border-color: #81C8E4;
   --info-background-color: #E5F5F9;


### PR DESCRIPTION
[![HTM-2020](https://badgen.net/badge/JIRA/HTM-2020/7A54FF?icon=jira)](https://b3partners.atlassian.net/browse/HTM-2020) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=Tailormap&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

To comply to WCAG contrast requirements 

[HTM-2020]: https://b3partners.atlassian.net/browse/HTM-2020?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ