### PR TITLE
HTM-2022: Give buttons of split button correct aria labels

### DIFF
--- a/projects/shared/assets/locale/messages.shared.de.xlf
+++ b/projects/shared/assets/locale/messages.shared.de.xlf
@@ -226,8 +226,8 @@
         <target>Passwort zurücksetzen</target>
       </trans-unit>
       <trans-unit id="shared.split-button.cycle-aria-label" datatype="html">
-        <source>Showing <x id="PH" equiv-text="this.getLabel()"/> – click to switch to <x id="PH_1" equiv-text="this.getNextLabel()"/></source>
-        <target>Zeige <x id="PH" equiv-text="this.getLabel()"/> – zum Wechseln auf <x id="PH_1" equiv-text="this.getNextLabel()"/> klicken</target>
+        <source>Showing <x id="PH" equiv-text="this.getLabel()"/> – click to switch to <x id="PH_1" equiv-text="nextLabel"/></source>
+        <target state="new">Zeige <x id="PH" equiv-text="this.getLabel()"/> – zum Wechseln auf <x id="PH_1" equiv-text="nextLabel"/> klicken</target>
       </trans-unit>
       <trans-unit id="shared.tree.items" datatype="html">
         <source><x id="PH" equiv-text="dragNodeIds.length"/> items</source>

--- a/projects/shared/assets/locale/messages.shared.de.xlf
+++ b/projects/shared/assets/locale/messages.shared.de.xlf
@@ -225,6 +225,10 @@
         <source>Reset Password</source>
         <target>Passwort zurücksetzen</target>
       </trans-unit>
+      <trans-unit id="shared.split-button.cycle-aria-label" datatype="html">
+        <source>Showing <x id="PH" equiv-text="this.getLabel()"/> – click to switch to <x id="PH_1" equiv-text="this.getNextLabel()"/></source>
+        <target>Zeige <x id="PH" equiv-text="this.getLabel()"/> – zum Wechseln auf <x id="PH_1" equiv-text="this.getNextLabel()"/> klicken</target>
+      </trans-unit>
       <trans-unit id="shared.tree.items" datatype="html">
         <source><x id="PH" equiv-text="dragNodeIds.length"/> items</source>
         <target><x id="PH" equiv-text="dragNodeIds.length"/> Elemente</target>

--- a/projects/shared/assets/locale/messages.shared.en.xlf
+++ b/projects/shared/assets/locale/messages.shared.en.xlf
@@ -171,7 +171,7 @@
         <source>Reset Password</source>
       </trans-unit>
       <trans-unit id="shared.split-button.cycle-aria-label" datatype="html">
-        <source>Showing <x id="PH" equiv-text="this.getLabel()"/> – click to switch to <x id="PH_1" equiv-text="this.getNextLabel()"/></source>
+        <source>Showing <x id="PH" equiv-text="this.getLabel()"/> – click to switch to <x id="PH_1" equiv-text="nextLabel"/></source>
       </trans-unit>
       <trans-unit id="shared.tree.items" datatype="html">
         <source><x id="PH" equiv-text="dragNodeIds.length"/> items</source>

--- a/projects/shared/assets/locale/messages.shared.en.xlf
+++ b/projects/shared/assets/locale/messages.shared.en.xlf
@@ -170,6 +170,9 @@
       <trans-unit id="shared.password-reset-request-form.title" datatype="html">
         <source>Reset Password</source>
       </trans-unit>
+      <trans-unit id="shared.split-button.cycle-aria-label" datatype="html">
+        <source>Showing <x id="PH" equiv-text="this.getLabel()"/> – click to switch to <x id="PH_1" equiv-text="this.getNextLabel()"/></source>
+      </trans-unit>
       <trans-unit id="shared.tree.items" datatype="html">
         <source><x id="PH" equiv-text="dragNodeIds.length"/> items</source>
       </trans-unit>

--- a/projects/shared/assets/locale/messages.shared.nl.xlf
+++ b/projects/shared/assets/locale/messages.shared.nl.xlf
@@ -225,6 +225,10 @@
         <source>Reset Password</source>
         <target>Wachtwoord opnieuw instellen</target>
       </trans-unit>
+      <trans-unit id="shared.split-button.cycle-aria-label" datatype="html">
+        <source>Showing <x id="PH" equiv-text="this.getLabel()"/> – click to switch to <x id="PH_1" equiv-text="this.getNextLabel()"/></source>
+        <target>Toont <x id="PH" equiv-text="this.getLabel()"/> – klik om te schakelen naar <x id="PH_1" equiv-text="this.getNextLabel()"/></target>
+      </trans-unit>
       <trans-unit id="shared.tree.items" datatype="html">
         <source><x id="PH" equiv-text="dragNodeIds.length"/> items</source>
         <target><x id="PH" equiv-text="dragNodeIds.length"/> items</target>

--- a/projects/shared/assets/locale/messages.shared.nl.xlf
+++ b/projects/shared/assets/locale/messages.shared.nl.xlf
@@ -226,8 +226,8 @@
         <target>Wachtwoord opnieuw instellen</target>
       </trans-unit>
       <trans-unit id="shared.split-button.cycle-aria-label" datatype="html">
-        <source>Showing <x id="PH" equiv-text="this.getLabel()"/> – click to switch to <x id="PH_1" equiv-text="this.getNextLabel()"/></source>
-        <target><x id="PH" equiv-text="this.getLabel()"/> wordt getoond – klik om te schakelen naar <x id="PH_1" equiv-text="this.getNextLabel()"/></target>
+        <source>Showing <x id="PH" equiv-text="this.getLabel()"/> – click to switch to <x id="PH_1" equiv-text="nextLabel"/></source>
+        <target state="new"><x id="PH" equiv-text="this.getLabel()"/> wordt getoond – klik om te schakelen naar <x id="PH_1" equiv-text="nextLabel"/></target>
       </trans-unit>
       <trans-unit id="shared.tree.items" datatype="html">
         <source><x id="PH" equiv-text="dragNodeIds.length"/> items</source>

--- a/projects/shared/assets/locale/messages.shared.nl.xlf
+++ b/projects/shared/assets/locale/messages.shared.nl.xlf
@@ -227,7 +227,7 @@
       </trans-unit>
       <trans-unit id="shared.split-button.cycle-aria-label" datatype="html">
         <source>Showing <x id="PH" equiv-text="this.getLabel()"/> – click to switch to <x id="PH_1" equiv-text="this.getNextLabel()"/></source>
-        <target>Toont <x id="PH" equiv-text="this.getLabel()"/> – klik om te schakelen naar <x id="PH_1" equiv-text="this.getNextLabel()"/></target>
+        <target><x id="PH" equiv-text="this.getLabel()"/> wordt getoond – klik om te schakelen naar <x id="PH_1" equiv-text="this.getNextLabel()"/></target>
       </trans-unit>
       <trans-unit id="shared.tree.items" datatype="html">
         <source><x id="PH" equiv-text="dragNodeIds.length"/> items</source>

--- a/projects/shared/src/lib/components/split-button/split-button.component.html
+++ b/projects/shared/src/lib/components/split-button/split-button.component.html
@@ -1,11 +1,13 @@
 <mat-button-toggle-group [class.hide-on-small-screens]="!!small_screens_icon" [hideSingleSelectionIndicator]="true">
-  <mat-button-toggle (click)="cycleNextOption()" [aria-label]="getNextLabel()" [tmTooltip]="getNextLabel()"
+  <mat-button-toggle (click)="cycleNextOption()" [aria-label]="getCycleAriaLabel()" [tmTooltip]="getNextLabel()"
                      class="cycle-button">
     {{ getLabel() }}
   </mat-button-toggle>
   <mat-button-toggle [matMenuTriggerFor]="dropdownMenu" class="drop-down-button"
                      i18n-tmTooltip="@@core.background-layer-toggle.expand-button"
-                     tmTooltip="Select basemap">
+                     tmTooltip="Select basemap"
+                     aria-label="Select basemap"
+                     i18n-aria-label="@@core.background-layer-toggle.expand-button">
     <mat-icon svgIcon="drop_down"></mat-icon>
   </mat-button-toggle>
 </mat-button-toggle-group>

--- a/projects/shared/src/lib/components/split-button/split-button.component.spec.ts
+++ b/projects/shared/src/lib/components/split-button/split-button.component.spec.ts
@@ -47,27 +47,27 @@ describe('SplitButtonComponent', () => {
   test('cycle button has aria-label set to next option on initial render', async () => {
     await setup();
     const buttons = screen.getAllByRole('radio');
-    expect(buttons[0].getAttribute('aria-label')).toBe('Show Test 2');
+    expect(buttons[0].getAttribute('aria-label')).toBe('Showing Test 1 – click to switch to Test 2');
   });
 
   test('cycle button aria-label updates after cycling', async () => {
     await setup();
     const buttons = screen.getAllByRole('radio');
-    expect(buttons[0].getAttribute('aria-label')).toBe('Show Test 2');
+    expect(buttons[0].getAttribute('aria-label')).toBe('Showing Test 1 – click to switch to Test 2');
     await userEvent.click(buttons[0]);
-    expect(buttons[0].getAttribute('aria-label')).toBe('Show Test 1');
+    expect(buttons[0].getAttribute('aria-label')).toBe('Showing Test 2 – click to switch to Test 1');
     await userEvent.click(buttons[0]);
-    expect(buttons[0].getAttribute('aria-label')).toBe('Show Test 2');
+    expect(buttons[0].getAttribute('aria-label')).toBe('Showing Test 1 – click to switch to Test 2');
   });
 
   test('cycle button aria-label updates after selecting from dropdown', async () => {
     await setup();
     const buttons = screen.getAllByRole('radio');
-    expect(buttons[0].getAttribute('aria-label')).toBe('Show Test 2');
+    expect(buttons[0].getAttribute('aria-label')).toBe('Showing Test 1 – click to switch to Test 2');
     await userEvent.click(buttons[1]);
     const menuItem = await screen.findByText('Test 2');
     await userEvent.click(menuItem);
-    expect(buttons[0].getAttribute('aria-label')).toBe('Show Test 1');
+    expect(buttons[0].getAttribute('aria-label')).toBe('Showing Test 2 – click to switch to Test 1');
   });
 
 });

--- a/projects/shared/src/lib/components/split-button/split-button.component.ts
+++ b/projects/shared/src/lib/components/split-button/split-button.component.ts
@@ -92,6 +92,10 @@ export class SplitButtonComponent {
     return $localize`:@@core.background-layer-toggle.show-next-option:Show ${nextLabel}:NEXT_LABEL:`;
   }
 
+  public getCycleAriaLabel(): string {
+    return $localize`:@@shared.split-button.cycle-aria-label:Showing ${this.getLabel()} – click to switch to ${this.getNextLabel()}`;
+  }
+
   public isLayerHiddenOnMap(option: SplitButtonOptionModel) {
     return this.in3D && this.layersWithoutWebMercator.includes(option.id);
   }

--- a/projects/shared/src/lib/components/split-button/split-button.component.ts
+++ b/projects/shared/src/lib/components/split-button/split-button.component.ts
@@ -93,7 +93,11 @@ export class SplitButtonComponent {
   }
 
   public getCycleAriaLabel(): string {
-    return $localize`:@@shared.split-button.cycle-aria-label:Showing ${this.getLabel()} – click to switch to ${this.getNextLabel()}`;
+    const nextLabel = this.nextOption?.label;
+    if (!nextLabel) {
+      return '';
+    }
+    return $localize`:@@shared.split-button.cycle-aria-label:Showing ${this.getLabel()} – click to switch to ${nextLabel}`;
   }
 
   public isLayerHiddenOnMap(option: SplitButtonOptionModel) {


### PR DESCRIPTION
[![HTM-2022](https://badgen.net/badge/JIRA/HTM-2022/7A54FF?icon=jira)](https://b3partners.atlassian.net/browse/HTM-2022) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=Tailormap&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

The accessible name of a button needs to include the visible text for WCAG requirements, so the aria label for the cycle button needed to be changed. 

[HTM-2022]: https://b3partners.atlassian.net/browse/HTM-2022?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ