### PR TITLE
HTM-2048: Prevent setting undefined header-height css variable

### DIFF
--- a/projects/admin-core/src/lib/application/components/header-config/header-component-config.component.ts
+++ b/projects/admin-core/src/lib/application/components/header-config/header-component-config.component.ts
@@ -42,7 +42,7 @@ export class HeaderComponentConfigComponent implements ConfigurationComponentMod
   @Input()
   public set config(config: HeaderComponentConfigModel | undefined) {
     this._config = config;
-    this.heightControl.patchValue(config?.height ?? 100, { emitEvent: false, onlySelf: true });
+    this.heightControl.patchValue(config?.height ?? 100, { onlySelf: true });
     this.cssControl.patchValue(config?.css ?? '', { emitEvent: false, onlySelf: true });
     this.initMenuItems(config);
   }

--- a/projects/admin-core/src/lib/application/components/header-config/header-component-config.component.ts
+++ b/projects/admin-core/src/lib/application/components/header-config/header-component-config.component.ts
@@ -42,7 +42,7 @@ export class HeaderComponentConfigComponent implements ConfigurationComponentMod
   @Input()
   public set config(config: HeaderComponentConfigModel | undefined) {
     this._config = config;
-    this.heightControl.patchValue(config?.height ?? 100, { onlySelf: true });
+    this.heightControl.patchValue(config?.height ?? 100, { emitEvent: config?.height === undefined, onlySelf: true });
     this.cssControl.patchValue(config?.css ?? '', { emitEvent: false, onlySelf: true });
     this.initMenuItems(config);
   }

--- a/projects/core/src/lib/components/header/header/header.component.ts
+++ b/projects/core/src/lib/components/header/header/header.component.ts
@@ -32,7 +32,8 @@ export class HeaderComponent implements OnDestroy {
       const headerContainer = this.headerContainer();
       const mobileHeader = this.mobileHeader();
       if (config && config.config && headerContainer) {
-        const componentHeight = mobileHeader ? Math.min(50, config.config.height) : config.config.height;
+        const configuredHeight = config.config.height || 100;
+        const componentHeight = mobileHeader ? Math.min(50, configuredHeight) : configuredHeight;
         CssHelper.setCssVariableValue('--header-component-height', componentHeight + 'px');
         CssHelper.setCssVariableValue('--header-text-color', config.config.textColor || '#000000', headerContainer.nativeElement);
         CssHelper.setCssVariableValue('--header-background-color', config.config.backgroundColor || '#ffffff', headerContainer.nativeElement);


### PR DESCRIPTION
[![HTM-2048](https://badgen.net/badge/JIRA/HTM-2048/7A54FF?icon=jira)](https://b3partners.atlassian.net/browse/HTM-2048) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=Tailormap&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

- Prevent saving header config without height
- Use height of 100 in viewer if height is undefined 

[HTM-2048]: https://b3partners.atlassian.net/browse/HTM-2048?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ