### PR TITLE
HTM-2064: Make snapping tool buttons and split button buttons clickable with keyboard

### DIFF
--- a/projects/core/src/lib/components/toolbar/snapping/snapping.component.html
+++ b/projects/core/src/lib/components/toolbar/snapping/snapping.component.html
@@ -5,9 +5,9 @@
         <mat-icon svgIcon="tools_snap"></mat-icon>
       </mat-button-toggle>
       <mat-button-toggle class="drop-down-button"
-                         #dropdownTrigger="matMenuTrigger"
+                         #snappingDropdownTrigger="matMenuTrigger"
                          [matMenuTriggerFor]="dropdownMenu"
-                         (keydown.enter)="dropdownTrigger.toggleMenu()">
+                         (keydown.enter)="snappingDropdownTrigger.toggleMenu()">
         <mat-icon svgIcon="drop_down"></mat-icon>
       </mat-button-toggle>
     </mat-button-toggle-group>

--- a/projects/core/src/lib/components/toolbar/snapping/snapping.component.html
+++ b/projects/core/src/lib/components/toolbar/snapping/snapping.component.html
@@ -1,11 +1,13 @@
 @if (hasSelectableLayers$ | async) {
   <div class="map-control-button-container">
     <mat-button-toggle-group [hideSingleSelectionIndicator]="true" [tmTooltip]="tooltip()">
-      <mat-button-toggle [class.selected]="toolActive$ | async" (click)="toggleTool()">
+      <mat-button-toggle [class.selected]="toolActive$ | async" (click)="toggleTool()" (keydown.enter)="toggleTool()">
         <mat-icon svgIcon="tools_snap"></mat-icon>
       </mat-button-toggle>
       <mat-button-toggle class="drop-down-button"
-                         [matMenuTriggerFor]="dropdownMenu">
+                         #dropdownTrigger="matMenuTrigger"
+                         [matMenuTriggerFor]="dropdownMenu"
+                         (keydown.enter)="dropdownTrigger.toggleMenu()">
         <mat-icon svgIcon="drop_down"></mat-icon>
       </mat-button-toggle>
     </mat-button-toggle-group>

--- a/projects/shared/src/lib/components/split-button/split-button.component.html
+++ b/projects/shared/src/lib/components/split-button/split-button.component.html
@@ -1,13 +1,18 @@
 <mat-button-toggle-group [class.hide-on-small-screens]="!!small_screens_icon" [hideSingleSelectionIndicator]="true">
-  <mat-button-toggle (click)="cycleNextOption()" [aria-label]="getCycleAriaLabel()" [tmTooltip]="getNextLabel()"
+  <mat-button-toggle (click)="cycleNextOption()"
+                     [aria-label]="getCycleAriaLabel()"
+                     [tmTooltip]="getNextLabel()"
+                     (keydown.enter)="cycleNextOption()"
                      class="cycle-button">
     {{ getLabel() }}
   </mat-button-toggle>
   <mat-button-toggle [matMenuTriggerFor]="dropdownMenu" class="drop-down-button"
+                     #splitButtonDropdownTrigger="matMenuTrigger"
                      i18n-tmTooltip="@@core.background-layer-toggle.expand-button"
                      tmTooltip="Select basemap"
                      aria-label="Select basemap"
-                     i18n-aria-label="@@core.background-layer-toggle.expand-button">
+                     i18n-aria-label="@@core.background-layer-toggle.expand-button"
+                     (keydown.enter)="splitButtonDropdownTrigger.toggleMenu()">
     <mat-icon svgIcon="drop_down"></mat-icon>
   </mat-button-toggle>
 </mat-button-toggle-group>


### PR DESCRIPTION
[![HTM-2064](https://badgen.net/badge/JIRA/HTM-2064/7A54FF?icon=jira)](https://b3partners.atlassian.net/browse/HTM-2064) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=Tailormap&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

 

[HTM-2064]: https://b3partners.atlassian.net/browse/HTM-2064?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ