### PR TITLE
HTM-2192: Make the menubar panel resizable (width only)

### DIFF
--- a/projects/core/assets/locale/messages.core.de.xlf
+++ b/projects/core/assets/locale/messages.core.de.xlf
@@ -294,6 +294,10 @@
         <source>Expand panel</source>
         <target>Panel ausklappen</target>
       </trans-unit>
+      <trans-unit id="core.dialog.resize-panel" datatype="html">
+        <source>Resize panel</source>
+        <target>Panelgröße ändern</target>
+      </trans-unit>
       <trans-unit id="core.draw.delete-selected-feature" datatype="html">
         <source>Delete selected feature</source>
         <target>Ausgewähltes Objekt löschen</target>

--- a/projects/core/assets/locale/messages.core.en.xlf
+++ b/projects/core/assets/locale/messages.core.en.xlf
@@ -1031,6 +1031,9 @@
       <trans-unit id="core.shared.maximize-panel" datatype="html">
         <source>Maximize panel</source>
       </trans-unit>
+      <trans-unit id="core.dialog.resize-panel" datatype="html">
+        <source>Resize panel</source>
+      </trans-unit>
       <trans-unit id="core.shared.minimize-panel" datatype="html">
         <source>Minimize panel</source>
       </trans-unit>

--- a/projects/core/assets/locale/messages.core.nl.xlf
+++ b/projects/core/assets/locale/messages.core.nl.xlf
@@ -1382,6 +1382,10 @@
         <source>Minimize panel</source>
         <target>Paneel minimaliseren</target>
       </trans-unit>
+      <trans-unit id="core.dialog.resize-panel" datatype="html">
+        <source>Resize panel</source>
+        <target>Paneel formaat wijzigen</target>
+      </trans-unit>
       <trans-unit id="core.shared.restore-panel-height" datatype="html">
         <source>Restore panel height</source>
         <target>Paneelhoogte herstellen</target>

--- a/projects/core/src/lib/components/menubar/menubar-panel/menubar-panel.component.html
+++ b/projects/core/src/lib/components/menubar/menubar-panel/menubar-panel.component.html
@@ -1,7 +1,10 @@
-<tm-dialog [open]="(activeComponent$ | async) !== null"
-           [width]="panelWidth"
+<tm-dialog (closeDialog)="closeDialog()"
+           (widthChanged)="onPanelWidthChanged($event)"
+           [allowResize]="true"
+           [dialogTitle]="(activeComponent$ | async)?.dialogTitle || ''"
+           [maxWidth]="panelMaxWidth"
+           [open]="(activeComponent$ | async) !== null"
            [widthMargin]="panelWidthMargin"
-           (closeDialog)="closeDialog()"
-           [dialogTitle]="(activeComponent$ | async)?.dialogTitle || ''">
+           [width]="panelWidth">
   <ng-content></ng-content>
 </tm-dialog>

--- a/projects/core/src/lib/components/menubar/menubar-panel/menubar-panel.component.spec.ts
+++ b/projects/core/src/lib/components/menubar/menubar-panel/menubar-panel.component.spec.ts
@@ -14,6 +14,8 @@ const getMenuBarServiceMock = (initialValue: { componentId: string; dialogTitle:
     provide: MenubarService,
     useValue: {
       activeComponent$,
+      panelWidth: 300,
+      setPanelWidth: jest.fn(),
       getActiveComponent$: () => activeComponent$.asObservable(),
       closePanel: jest.fn().mockImplementation(() => activeComponent$.next(null)),
     },
@@ -51,4 +53,26 @@ describe('MenubarPanelComponent', () => {
     expect(closePanelFn).toHaveBeenCalled();
   });
 
+
+  test('onPanelWidthChanged updates panelWidth and calls MenubarService.setPanelWidth', async () => {
+    const menubarServiceMock = getMenuBarServiceMock({ componentId: 'TOC', dialogTitle: 'Available layers' });
+    const setPanelWidthFn = menubarServiceMock.useValue.setPanelWidth;
+    const { fixture } = await render(MenubarPanelComponent, {
+      imports: [ SharedModule, MatIconTestingModule, CoreSharedModule ],
+      providers: [
+        menubarServiceMock,
+        { provide: ViewerLayoutService, useValue: { setLeftPadding: jest.fn(), setRightPadding: jest.fn() } },
+      ],
+    });
+    await fixture.whenStable();
+    const component = fixture.componentInstance;
+    const initialWidth = component.panelWidth;
+
+    const newWidth = 450;
+    component.onPanelWidthChanged(newWidth);
+
+    expect(component.panelWidth).toBe(newWidth);
+    expect(setPanelWidthFn).toHaveBeenCalledWith(newWidth);
+    expect(component.panelWidth).not.toBe(initialWidth);
+  });
 });

--- a/projects/core/src/lib/components/menubar/menubar-panel/menubar-panel.component.ts
+++ b/projects/core/src/lib/components/menubar/menubar-panel/menubar-panel.component.ts
@@ -14,10 +14,10 @@ import { debounceTime } from 'rxjs/operators';
 export class MenubarPanelComponent implements OnDestroy {
   private menubarService = inject(MenubarService);
 
-
   public activeComponent$: Observable<{ componentId: string; dialogTitle: string } | null>;
 
   public panelWidth = 300;
+  public panelMaxWidth = 600;
   public panelWidthMargin = CssHelper.getCssVariableValueNumeric('--menubar-width');
 
   constructor() {
@@ -36,4 +36,8 @@ export class MenubarPanelComponent implements OnDestroy {
     this.menubarService.closePanel();
   }
 
+  public onPanelWidthChanged(width: number) {
+    this.panelWidth = width;
+    this.menubarService.setPanelWidth(width);
+  }
 }

--- a/projects/core/src/lib/components/menubar/menubar.service.ts
+++ b/projects/core/src/lib/components/menubar/menubar.service.ts
@@ -16,6 +16,11 @@ export class MenubarService {
   private activeComponent$ = new BehaviorSubject<{ componentId: string; dialogTitle: string } | null>(null);
 
   public panelWidth = 300;
+
+  public setPanelWidth(width: number) {
+    this.panelWidth = width;
+  }
+
   private mobilePanelHeight$ = new BehaviorSubject<number | null>(null);
 
   public toggleActiveComponent(componentId: string, dialogTitle: string) {

--- a/projects/core/src/lib/shared/components/dialog/dialog.component.css
+++ b/projects/core/src/lib/shared/components/dialog/dialog.component.css
@@ -72,3 +72,29 @@
   flex: 1;
   overflow: hidden;
 }
+
+.dialog-resize-handle {
+  position: absolute;
+  top: 0;
+  right: -4px;
+  bottom: 0;
+  width: 8px;
+  cursor: ew-resize;
+  z-index: 2;
+  outline: none;
+  touch-action: none;
+}
+
+.dialog-resize-handle:hover {
+  background-color: var(--border-color);
+}
+
+.dialog-resize-handle:focus {
+  background-color: var(--primary-color);
+  box-shadow: inset 0 0 0 2px var(--primary-color-0_5);
+}
+
+.dialog-resize-handle--left {
+  left: -4px;
+  right: auto;
+}

--- a/projects/core/src/lib/shared/components/dialog/dialog.component.html
+++ b/projects/core/src/lib/shared/components/dialog/dialog.component.html
@@ -37,5 +37,20 @@
     <div class="dialog-content">
       <ng-content></ng-content>
     </div>
+    @if (allowResize && !fullscreen) {
+      <div
+        (keydown)="onResizeHandleKeyDown($event)"
+        (pointerdown)="startResize($event)"
+        [attr.aria-label]="getResizeHandleLabel()"
+        [attr.aria-orientation]="openFromRight ? 'horizontal' : 'horizontal'"
+        [attr.aria-valuemax]="getMaxAllowedWidth()"
+        [attr.aria-valuemin]="minWidth"
+        [attr.aria-valuenow]="width"
+        [class.dialog-resize-handle--left]="openFromRight"
+        class="dialog-resize-handle"
+        role="slider"
+        tabindex="0">
+      </div>
+    }
   </div>
 }

--- a/projects/core/src/lib/shared/components/dialog/dialog.component.ts
+++ b/projects/core/src/lib/shared/components/dialog/dialog.component.ts
@@ -3,7 +3,7 @@ import { style, transition, trigger, animate } from '@angular/animations';
 import { DialogService } from './dialog.service';
 import { BrowserHelper } from '@tailormap-viewer/shared';
 
-const DEFAULT_WIDTH = 300;
+const DIALOG_DEFAULT_WIDTH = 300;
 
 @Component({
   selector: 'tm-dialog',
@@ -49,13 +49,22 @@ export class DialogComponent implements OnInit, OnChanges, OnDestroy {
   public collapsed: boolean | null = false;
 
   @Input()
-  public width = DEFAULT_WIDTH;
+  public width = DIALOG_DEFAULT_WIDTH;
 
   @Input()
   public widthMargin = 0;
 
   @Input()
   public allowFullscreen = false;
+
+  @Input()
+  public allowResize = false;
+
+  @Input()
+  public minWidth = DIALOG_DEFAULT_WIDTH;
+
+  @Input()
+  public maxWidth: number | null = null;
 
   @Output()
   public closeDialog = new EventEmitter();
@@ -65,6 +74,9 @@ export class DialogComponent implements OnInit, OnChanges, OnDestroy {
 
   @Output()
   public toggleFullscreenDialog = new EventEmitter<boolean>();
+
+  @Output()
+  public widthChanged = new EventEmitter<number>();
 
   public fullscreen = false;
 
@@ -79,15 +91,39 @@ export class DialogComponent implements OnInit, OnChanges, OnDestroy {
     this.dialogService.dialogChanged(this.dialogId, this.getLeft(), this.getRight());
   }
 
-  public actualWidth = DEFAULT_WIDTH;
+  public actualWidth = DIALOG_DEFAULT_WIDTH;
   public dialogId = '';
+  private resizeActive = false;
+  private resizeStartX = 0;
+  private resizeStartWidth = DIALOG_DEFAULT_WIDTH;
+  private readonly RESIZE_KEYBOARD_STEP = 10;
 
   public ngOnInit(): void {
     this.dialogId = this.dialogService.registerDialog(this.getLeft(), this.getRight());
   }
 
   public ngOnDestroy(): void {
+    this.stopResize();
     this.dialogService.unregisterDialog(this.dialogId);
+  }
+
+  @HostListener('document:pointermove', ['$event']) public onDocumentPointerMove(event: PointerEvent) {
+    if (!this.resizeActive) {
+      return;
+    }
+    const delta = this.openFromRight ? this.resizeStartX - event.clientX : event.clientX - this.resizeStartX;
+    const maxWidth = this.getMaxAllowedWidth();
+    const nextWidth = Math.max(this.minWidth, Math.min(this.resizeStartWidth + delta, maxWidth));
+    if (nextWidth !== this.width) {
+      this.width = nextWidth;
+      this.updateActualWidth();
+      this.widthChanged.emit(nextWidth);
+      this.dialogService.dialogChanged(this.dialogId, this.getLeft(), this.getRight());
+    }
+  }
+
+  @HostListener('document:pointerup') public onDocumentPointerUp() {
+    this.stopResize();
   }
 
   public ngOnChanges(changes: SimpleChanges): void {
@@ -97,14 +133,65 @@ export class DialogComponent implements OnInit, OnChanges, OnDestroy {
       changes['open']?.currentValue !== changes['open']?.previousValue ||
       changes['openFromRight']?.currentValue !== changes['openFromRight']?.previousValue ||
       changes['width']?.currentValue !== changes['width']?.previousValue ||
-      changes['maxWidth']?.currentValue !== changes['maxWidth']?.previousValue
+      changes['maxWidth']?.currentValue !== changes['maxWidth']?.previousValue ||
+      changes['minWidth']?.currentValue !== changes['minWidth']?.previousValue
     ) {
       this.dialogService.dialogChanged(this.dialogId, this.getLeft(), this.getRight());
     }
   }
 
   public updateActualWidth() {
-    this.actualWidth = Math.min(this.width, BrowserHelper.getScreenWith() - this.widthMargin);
+    this.actualWidth = Math.max(this.minWidth, Math.min(this.width, this.getMaxAllowedWidth()));
+  }
+
+  protected getMaxAllowedWidth(): number {
+    const viewportMaxWidth = BrowserHelper.getScreenWith() - this.widthMargin;
+    return this.maxWidth !== null ? Math.min(this.maxWidth, viewportMaxWidth) : viewportMaxWidth;
+  }
+
+  public startResize(event: PointerEvent) {
+    if (!this.allowResize || this.fullscreen) {
+      return;
+    }
+    event.preventDefault();
+    this.resizeActive = true;
+    this.resizeStartX = event.clientX;
+    this.resizeStartWidth = this.width;
+    document.body.classList.add('resize-active');
+  }
+
+  public onResizeHandleKeyDown(event: KeyboardEvent) {
+    if (!this.allowResize || this.fullscreen) {
+      return;
+    }
+    let newWidth: number | null = null;
+    const maxWidth = this.getMaxAllowedWidth();
+
+    if (this.openFromRight && event.key === 'ArrowLeft') {
+      newWidth = Math.min(this.width + this.RESIZE_KEYBOARD_STEP, maxWidth);
+    } else if (this.openFromRight && event.key === 'ArrowRight') {
+      newWidth = Math.max(this.width - this.RESIZE_KEYBOARD_STEP, this.minWidth);
+    } else if (!this.openFromRight && event.key === 'ArrowRight') {
+      newWidth = Math.min(this.width + this.RESIZE_KEYBOARD_STEP, maxWidth);
+    } else if (!this.openFromRight && event.key === 'ArrowLeft') {
+      newWidth = Math.max(this.width - this.RESIZE_KEYBOARD_STEP, this.minWidth);
+    }
+
+    if (newWidth !== null && newWidth !== this.width) {
+      event.preventDefault();
+      this.width = newWidth;
+      this.updateActualWidth();
+      this.widthChanged.emit(newWidth);
+      this.dialogService.dialogChanged(this.dialogId, this.getLeft(), this.getRight());
+    }
+  }
+
+  private stopResize() {
+    if (!this.resizeActive) {
+      return;
+    }
+    this.resizeActive = false;
+    document.body.classList.remove('resize-active');
   }
 
   private getHidden() {
@@ -138,4 +225,7 @@ export class DialogComponent implements OnInit, OnChanges, OnDestroy {
       : $localize`:@@core.dialog.collapse-panel:Collapse panel`;
   }
 
+  public getResizeHandleLabel(): string {
+    return $localize`:@@core.dialog.resize-panel:Resize panel`;
+  }
 }


### PR DESCRIPTION
[![HTM-2192](https://badgen.net/badge/JIRA/HTM-2192/7A54FF?icon=jira)](https://b3partners.atlassian.net/browse/HTM-2192) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=Tailormap&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

This will make the menubar panel resizable within the range of minimum 300px and maximum 600px, with the default/starting width of 300px.
Resize can be done using keyboard as well.

[HTM-2192]: https://b3partners.atlassian.net/browse/HTM-2192?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ