### PR TITLE
HTM-2210: For readable layer visibility bookmark, also support selecting service by id in addition to title

### DIFF
--- a/projects/core/src/lib/services/application-bookmark/bookmark-fragment-handlers/readable-visibility-bookmark-handler.service.spec.ts
+++ b/projects/core/src/lib/services/application-bookmark/bookmark-fragment-handlers/readable-visibility-bookmark-handler.service.spec.ts
@@ -2,9 +2,9 @@ import { ReadableVisibilityBookmarkHandlerService } from './readable-visibility-
 import { ExtendedAppLayerModel } from '../../../map/models';
 
 const layers = [
-  { id: '1', layerName: 'layer1', service: { title: 'service' } },
-  { id: '2', layerName: 'layer2', service: { title: 'service' } },
-  { id: '3', layerName: 'layer1', service: { title: 'service2' } },
+  { id: '1', layerName: 'layer1', service: { id: 's1', title: 'service' } },
+  { id: '2', layerName: 'layer2', service: { id: 's1', title: 'service' } },
+  { id: '3', layerName: 'layer1', service: { id: 's2', title: 'service2' } },
 ] as ExtendedAppLayerModel[];
 
 describe('ReadableVisibilityBookmarkHandler', () => {
@@ -13,10 +13,16 @@ describe('ReadableVisibilityBookmarkHandler', () => {
     // bookmark, result, background ids
     [ '', null, []],
     [ 'only=service/layer1', [{ id: '1', checked: true }, { id: '2', checked: false }, { id: '3', checked: false }], []],
+    [ 'only=s1/layer1',      [{ id: '1', checked: true }, { id: '2', checked: false }, { id: '3', checked: false }], []],
     [ 'only=service1/layer1', [{ id: '1', checked: false }, { id: '2', checked: false }, { id: '3', checked: false }], []],
+    [ 'only=s0000/layer1',    [{ id: '1', checked: false }, { id: '2', checked: false }, { id: '3', checked: false }], []],
     [ 'only=service/layer1,layer2', [{ id: '1', checked: true }, { id: '2', checked: true }, { id: '3', checked: false }], []],
+    [ 'only=s1/layer1,layer2',      [{ id: '1', checked: true }, { id: '2', checked: true }, { id: '3', checked: false }], []],
     [ 'only=service/layer1,layer2;service2/layer1', [{ id: '1', checked: true }, { id: '2', checked: true }, { id: '3', checked: true }], []],
+    [ 'only=service/layer1,layer2;s2/layer1',       [{ id: '1', checked: true }, { id: '2', checked: true }, { id: '3', checked: true }], []],
+    [ 'only=s1/layer1,layer2;s2/layer1',            [{ id: '1', checked: true }, { id: '2', checked: true }, { id: '3', checked: true }], []],
     [ 'only=service/layer1', [{ id: '1', checked: true }, { id: '2', checked: false }], ['3']],
+    [ 'only=s1/layer1',      [{ id: '1', checked: true }, { id: '2', checked: false }], ['3']],
   ];
 
   test.each(tests)(

--- a/projects/core/src/lib/services/application-bookmark/bookmark-fragment-handlers/readable-visibility-bookmark-handler.service.ts
+++ b/projects/core/src/lib/services/application-bookmark/bookmark-fragment-handlers/readable-visibility-bookmark-handler.service.ts
@@ -16,14 +16,15 @@ import { MatSnackBar } from '@angular/material/snack-bar';
 /**
  * This bookmark handler reads the layers part of the bookmark when starting the application only. Does not respond to changes afterward.
  *
- * Format is layers:only=service_title/layername
+ * Format is layers:only=service_title/layername or service_id/layername (everywhere service_title is used below, service_id can also be used)
  * Support for multiple combinations, separated with semicolon: layers:only=service_title/layername;other_service=other_layer
  * Support for multiple layers per service with comma in layer list: layers:only=service_title/layername,layer2
  *
  * Future idea:
- * Replace the current json layer visibility changes url into something readable by combining these functions
+ * Replace the current json layer visibility changes (with opacity, etc.) url into something readable by combining these functions
  * For example
  * layers:only=service_title/layername;c=service_title/layername:0|1@50...
+ * Or also add layers:show or layers:hide.
  */
 
 @Injectable({

--- a/projects/core/src/lib/services/application-bookmark/bookmark-fragment-handlers/readable-visibility-bookmark-handler.service.ts
+++ b/projects/core/src/lib/services/application-bookmark/bookmark-fragment-handlers/readable-visibility-bookmark-handler.service.ts
@@ -101,7 +101,7 @@ export class ReadableVisibilityBookmarkHandlerService implements BookmarkFragmen
       const layerNames = new Set(layerNamesPart.split(ReadableVisibilityBookmarkHandlerService.LAYER_SEPARATOR));
       layers
         .filter(l => {
-          return l.service?.title === serviceName && layerNames.has(l.layerName);
+          return (l.service?.title === serviceName || l.service?.id === serviceName) && layerNames.has(l.layerName);
         })
         .forEach(foundLayer => {
           enabledLayers.add(foundLayer.id);


### PR DESCRIPTION
[![HTM-2210](https://badgen.net/badge/JIRA/HTM-2210/7A54FF?icon=jira)](https://b3partners.atlassian.net/browse/HTM-2210) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=Tailormap&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

This makes it more compatible with the feature selection bookmark which only supports selection by service id.

The service title is more "readable" than the ID, but can easily lead to broken bookmarks because it can change. 

[HTM-2210]: https://b3partners.atlassian.net/browse/HTM-2210?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ