### PR TITLE
HTM-2154: Make the split button keyboard accessible

### DIFF
--- a/projects/shared/src/lib/components/split-button/split-button.component.css
+++ b/projects/shared/src/lib/components/split-button/split-button.component.css
@@ -1,36 +1,40 @@
-.mat-button-toggle,
-.mat-button-toggle.mat-button-toggle-checked {
+.split-button-group {
   background-color: #fff;
 }
 
-mat-button-toggle-group {
-  border-radius: 3px;
-}
-
-.cycle-button ::ng-deep .mat-button-toggle-label-content {
+.cycle-button ::ng-deep .mdc-button__label {
   max-width: calc(var(--100vw) - 580px);
   text-overflow: ellipsis;
   overflow: hidden;
 }
 
-mat-button-toggle ::ng-deep .mat-button-toggle-label-content {
+.cycle-button ::ng-deep .mdc-button__label,
+.drop-down-button {
   line-height: 38px;
 }
 
-.drop-down-button ::ng-deep .mat-button-toggle-label-content {
-  padding: 0 8px;
+.split-button-button {
+  border: none;
+  background: none;
 }
 
-.drop-down-button ::ng-deep .mat-button-toggle-label-content svg {
+.drop-down-button {
+  width: 40px;
+  min-width: 40px;
+  padding: 0;
+}
+
+.drop-down-button mat-icon {
+  padding: 0;
+  margin: 0;
   width: 20px;
   height: 20px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }
 
-.mat-button-toggle + .mat-button-toggle {
-  border-left: 0 none;
-}
-
-.map-control-button-container {
+.map-control-button-container:not(.split-button-group) {
   display: none;
   overflow: hidden;
 }

--- a/projects/shared/src/lib/components/split-button/split-button.component.html
+++ b/projects/shared/src/lib/components/split-button/split-button.component.html
@@ -1,21 +1,23 @@
-<mat-button-toggle-group [class.hide-on-small-screens]="!!small_screens_icon" [hideSingleSelectionIndicator]="true">
-  <mat-button-toggle (click)="cycleNextOption()"
-                     [aria-label]="getCycleAriaLabel()"
-                     [tmTooltip]="getNextLabel()"
-                     (keydown.enter)="cycleNextOption()"
-                     class="cycle-button">
+<div class="split-button-group map-control-button-container" [class.hide-on-small-screens]="!!small_screens_icon">
+  <button mat-flat-button
+          (click)="cycleNextOption()"
+          [tmTooltip]="getNextLabel()"
+          [tmExplicitAriaLabel]="getCycleAriaLabel()"
+          (keydown.enter)="cycleNextOption()"
+          class="split-button-button cycle-button">
     {{ getLabel() }}
-  </mat-button-toggle>
-  <mat-button-toggle [matMenuTriggerFor]="dropdownMenu" class="drop-down-button"
-                     #splitButtonDropdownTrigger="matMenuTrigger"
-                     i18n-tmTooltip="@@core.background-layer-toggle.expand-button"
-                     tmTooltip="Select basemap"
-                     aria-label="Select basemap"
-                     i18n-aria-label="@@core.background-layer-toggle.expand-button"
-                     (keydown.enter)="splitButtonDropdownTrigger.toggleMenu()">
+  </button>
+  <button mat-flat-button
+          [matMenuTriggerFor]="dropdownMenu"
+          class="split-button-button drop-down-button"
+          #splitButtonDropdownTrigger="matMenuTrigger"
+          i18n-tmTooltip="@@core.background-layer-toggle.expand-button"
+          tmTooltip="Select basemap"
+          aria-label="Select basemap"
+          i18n-aria-label="@@core.background-layer-toggle.expand-button">
     <mat-icon svgIcon="drop_down"></mat-icon>
-  </mat-button-toggle>
-</mat-button-toggle-group>
+  </button>
+</div>
 
 @if (small_screens_icon) {
   <div class="map-control-button-container">

--- a/projects/shared/src/lib/components/split-button/split-button.component.html
+++ b/projects/shared/src/lib/components/split-button/split-button.component.html
@@ -10,7 +10,6 @@
   <button mat-flat-button
           [matMenuTriggerFor]="dropdownMenu"
           class="split-button-button drop-down-button"
-          #splitButtonDropdownTrigger="matMenuTrigger"
           i18n-tmTooltip="@@core.background-layer-toggle.expand-button"
           tmTooltip="Select basemap"
           aria-label="Select basemap"
@@ -34,14 +33,16 @@
   @for (option of optionsList; track option.id) {
     <button mat-menu-item
       class="split-button-menu-item"
-      [tmTooltip]="option.label"
-      [matTooltipPosition]="'before'"
+      [aria-label]="option.label"
       [class.not-visible-in-3d]="isLayerHiddenOnMap(option)"
       (click)="selectOption(option.id)">
-      @if (option.id === selectedOptionId) {
-        <mat-icon svgIcon="check"></mat-icon>
-      }
-      {{ option.label }}
+      <span [tmTooltip]="option.label"
+            [matTooltipPosition]="'before'">
+        @if (option.id === selectedOptionId) {
+          <mat-icon svgIcon="check"></mat-icon>
+        }
+        {{ option.label }}
+      </span>
     </button>
   }
 </mat-menu>

--- a/projects/shared/src/lib/components/split-button/split-button.component.spec.ts
+++ b/projects/shared/src/lib/components/split-button/split-button.component.spec.ts
@@ -22,7 +22,7 @@ describe('SplitButtonComponent', () => {
 
   test('should render', async () => {
     await setup();
-    const buttons = screen.getAllByRole('radio');
+    const buttons = screen.getAllByRole('button');
     expect(buttons.length).toEqual(2);
     await userEvent.click(buttons[1]);
     const labels = await screen.findAllByText('Test 1');
@@ -34,7 +34,7 @@ describe('SplitButtonComponent', () => {
 
   test('cycles through options', async () => {
     const { optionSelectedMock } = await setup();
-    const buttons = screen.getAllByRole('radio');
+    const buttons = screen.getAllByRole('button');
     expect(await screen.getByText('Test 1'));
     await userEvent.click(buttons[0]);
     expect(optionSelectedMock).toHaveBeenCalledWith('2');
@@ -46,13 +46,13 @@ describe('SplitButtonComponent', () => {
 
   test('cycle button has aria-label set to next option on initial render', async () => {
     await setup();
-    const buttons = screen.getAllByRole('radio');
+    const buttons = screen.getAllByRole('button');
     expect(buttons[0].getAttribute('aria-label')).toBe('Showing Test 1 – click to switch to Test 2');
   });
 
   test('cycle button aria-label updates after cycling', async () => {
     await setup();
-    const buttons = screen.getAllByRole('radio');
+    const buttons = screen.getAllByRole('button');
     expect(buttons[0].getAttribute('aria-label')).toBe('Showing Test 1 – click to switch to Test 2');
     await userEvent.click(buttons[0]);
     expect(buttons[0].getAttribute('aria-label')).toBe('Showing Test 2 – click to switch to Test 1');
@@ -62,7 +62,7 @@ describe('SplitButtonComponent', () => {
 
   test('cycle button aria-label updates after selecting from dropdown', async () => {
     await setup();
-    const buttons = screen.getAllByRole('radio');
+    const buttons = screen.getAllByRole('button');
     expect(buttons[0].getAttribute('aria-label')).toBe('Showing Test 1 – click to switch to Test 2');
     await userEvent.click(buttons[1]);
     const menuItem = await screen.findByText('Test 2');

--- a/projects/shared/src/lib/directives/tooltip.directive.ts
+++ b/projects/shared/src/lib/directives/tooltip.directive.ts
@@ -7,6 +7,8 @@ import { MatTooltip } from '@angular/material/tooltip';
 })
 export class TooltipDirective extends MatTooltip {
 
+  private _explicitAriaLabel: string | null = null;
+
   @Input('tmTooltip')
   public set tooltip(tooltip: string | null) {
     if (tooltip) {
@@ -14,9 +16,17 @@ export class TooltipDirective extends MatTooltip {
     }
   }
 
+  // Allow explicitly setting an aria-label that is different from the tooltip.
+  @Input()
+  public set tmExplicitAriaLabel(ariaLabel: string | null) {
+    if (ariaLabel) {
+      this._explicitAriaLabel = ariaLabel;
+    }
+  }
+
   @HostBinding('attr.aria-label')
   public get ariaLabel() {
-    return this.message;
+    return this._explicitAriaLabel || this.message;
   }
 
 }


### PR DESCRIPTION
[![HTM-2154](https://badgen.net/badge/JIRA/HTM-2154/7A54FF?icon=jira)](https://b3partners.atlassian.net/browse/HTM-2154) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=Tailormap&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

Previously, the dropdown button in the split button was reachable by keyboard by using the arrow keys, now it is reachable with the tab key. The focus is now set to the first item in the dropdown menu after clicking the dropdown button with the keyboard. 

[HTM-2154]: https://b3partners.atlassian.net/browse/HTM-2154?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ