### PR TITLE
HTM-2231: Ensure using entire bookmark when creating 'share feature' link

### DIFF
--- a/projects/core/src/lib/services/application-bookmark/feature-selection-bookmark.service.ts
+++ b/projects/core/src/lib/services/application-bookmark/feature-selection-bookmark.service.ts
@@ -290,7 +290,6 @@ export class FeatureSelectionBookmarkService {
     ]).pipe(
       take(1),
       map(([ layer, bookmark ]) => {
-        console.log('bookmark', bookmark);
         if (!layer || !fid) {
           return null;
         }

--- a/projects/core/src/lib/services/application-bookmark/feature-selection-bookmark.service.ts
+++ b/projects/core/src/lib/services/application-bookmark/feature-selection-bookmark.service.ts
@@ -8,9 +8,7 @@ import { addFilterGroup, removeFilterGroup } from '../../state/filter-state/filt
 import { selectVisibleAppLayerIds, selectLayer, selectLayers, selectVisibleLayersWithAttributes } from '../../map';
 import { selectViewerId } from '../../state';
 import { LoadingStateEnum, SnackBarMessageComponent, SnackBarMessageOptionsModel } from '@tailormap-viewer/shared';
-import {
-  BehaviorSubject, catchError, combineLatest, concatMap, defaultIfEmpty, filter, forkJoin, map, Observable, of, take,
-} from 'rxjs';
+import { BehaviorSubject, catchError, combineLatest, concatMap, defaultIfEmpty, filter, forkJoin, map, Observable, of, take } from 'rxjs';
 import { CqlFilterHelper, FeaturesFilterHelper, FeaturesFilters } from '../../filter';
 import {
   emptyFeatureInfo,

--- a/projects/core/src/lib/services/application-bookmark/feature-selection-bookmark.service.ts
+++ b/projects/core/src/lib/services/application-bookmark/feature-selection-bookmark.service.ts
@@ -8,7 +8,9 @@ import { addFilterGroup, removeFilterGroup } from '../../state/filter-state/filt
 import { selectVisibleAppLayerIds, selectLayer, selectLayers, selectVisibleLayersWithAttributes } from '../../map';
 import { selectViewerId } from '../../state';
 import { LoadingStateEnum, SnackBarMessageComponent, SnackBarMessageOptionsModel } from '@tailormap-viewer/shared';
-import { BehaviorSubject, catchError, combineLatest, concatMap, filter, forkJoin, map, Observable, of, startWith, take } from 'rxjs';
+import {
+  BehaviorSubject, catchError, combineLatest, concatMap, defaultIfEmpty, filter, forkJoin, map, Observable, of, take,
+} from 'rxjs';
 import { CqlFilterHelper, FeaturesFilterHelper, FeaturesFilters } from '../../filter';
 import {
   emptyFeatureInfo,
@@ -286,10 +288,11 @@ export class FeatureSelectionBookmarkService {
   public getFidSelectionUrl$(appLayerId: string, fid: string): Observable<string | null> {
     return combineLatest([
       this.store$.select(selectLayer(appLayerId)),
-      this.bookmarkService.getBookmarkValue$().pipe(startWith('')),
+      this.bookmarkService.getBookmarkValue$().pipe(defaultIfEmpty('')),
     ]).pipe(
       take(1),
       map(([ layer, bookmark ]) => {
+        console.log('bookmark', bookmark);
         if (!layer || !fid) {
           return null;
         }


### PR DESCRIPTION
[![HTM-2231](https://badgen.net/badge/JIRA/HTM-2231/7A54FF?icon=jira)](https://b3partners.atlassian.net/browse/HTM-2231) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=Tailormap&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

Use defaultIfEmpty instead of startWith for getting the bookmark to make create the share feature link. This prevents it from sometimes overwriting the actual value with an empty string. 

[HTM-2231]: https://b3partners.atlassian.net/browse/HTM-2231?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ