### PR TITLE
HTM-2169: WCAG 4.1.2: fix misleading alt text for legend image

### DIFF
--- a/projects/core/src/lib/components/legend/legend-layer/legend-layer.component.spec.ts
+++ b/projects/core/src/lib/components/legend/legend-layer/legend-layer.component.spec.ts
@@ -28,7 +28,7 @@ describe('LegendLayerComponent', () => {
     const img = await screen.getByRole('img');
     expect(img).toBeInTheDocument();
     expect(img.getAttribute('src')).toEqual('some-url');
-    expect(img.getAttribute('alt')).toEqual('Failed to load legend for Layer title');
+    expect(img.getAttribute('alt')).toEqual('Legend for Layer title');
   });
 
   test('should render high dpi legend for GeoServer', async () => {

--- a/projects/shared/assets/locale/messages.shared.de.xlf
+++ b/projects/shared/assets/locale/messages.shared.de.xlf
@@ -253,9 +253,9 @@
         <source>German</source>
         <target>Deutsch</target>
       </trans-unit>
-      <trans-unit id="shared.legend-image.failed-loading-legend" datatype="html">
-        <source>Failed to load legend for</source>
-        <target>Legende konnte nicht geladen werden für</target>
+      <trans-unit id="shared.legend-image.alt-text" datatype="html">
+        <source>Legend for</source>
+        <target>Legende für</target>
       </trans-unit>
       <trans-unit id="shared.login-form.forgot-password" datatype="html">
         <source>Forgot your password?</source>

--- a/projects/shared/assets/locale/messages.shared.en.xlf
+++ b/projects/shared/assets/locale/messages.shared.en.xlf
@@ -191,8 +191,8 @@
       <trans-unit id="shared.language.german" datatype="html">
         <source>German</source>
       </trans-unit>
-      <trans-unit id="shared.legend-image.failed-loading-legend" datatype="html">
-        <source>Failed to load legend for</source>
+      <trans-unit id="shared.legend-image.alt-text" datatype="html">
+        <source>Legend for</source>
       </trans-unit>
       <trans-unit id="shared.login-form.forgot-password" datatype="html">
         <source>Forgot your password?</source>

--- a/projects/shared/assets/locale/messages.shared.nl.xlf
+++ b/projects/shared/assets/locale/messages.shared.nl.xlf
@@ -253,9 +253,9 @@
         <source>German</source>
         <target>Duits</target>
       </trans-unit>
-      <trans-unit id="shared.legend-image.failed-loading-legend" datatype="html">
-        <source>Failed to load legend for</source>
-        <target>Legenda niet geladen voor</target>
+      <trans-unit id="shared.legend-image.alt-text" datatype="html">
+        <source>Legend for</source>
+        <target>Legenda voor</target>
       </trans-unit>
       <trans-unit id="shared.login-form.forgot-password" datatype="html">
         <source>Forgot your password?</source>

--- a/projects/shared/src/lib/components/legend-image/legend-image.component.html
+++ b/projects/shared/src/lib/components/legend-image/legend-image.component.html
@@ -1,6 +1,6 @@
 @if (legendSettings(); as settings) {
   <img [class.hi-dpi]="settings.scaleHiDpiImage"
-       [alt]="settings.failedToLoadMessage"
+       [alt]="settings.altText"
        [src]="settings.url"
        [srcset]="settings.srcset" />
 }

--- a/projects/shared/src/lib/components/legend-image/legend-image.component.spec.ts
+++ b/projects/shared/src/lib/components/legend-image/legend-image.component.spec.ts
@@ -24,7 +24,7 @@ describe('LegendImageComponent', () => {
     const img = await screen.getByRole('img');
     expect(img).toBeInTheDocument();
     expect(img.getAttribute('src')).toEqual('some-url');
-    expect(img.getAttribute('alt')).toEqual('Failed to load legend for Layer title');
+    expect(img.getAttribute('alt')).toEqual('Legend for Layer title');
   });
 
   test('should render high dpi legend for GeoServer', async () => {

--- a/projects/shared/src/lib/components/legend-image/legend-image.component.ts
+++ b/projects/shared/src/lib/components/legend-image/legend-image.component.ts
@@ -11,11 +11,11 @@ export interface LegendImageModel {
 interface LegendImageSettingsModel {
   url: string;
   scaleHiDpiImage: boolean;
-  failedToLoadMessage: string;
+  altText: string;
   srcset: string;
 }
 
-const FAILED_TO_LOAD_MESSAGE = $localize `:@@shared.legend-image.failed-loading-legend:Failed to load legend for`;
+const LOCALISED_ALT_TEXT = $localize `:@@shared.legend-image.alt-text:Legend for`;
 
 @Component({
     selector: 'tm-legend-image',
@@ -70,7 +70,7 @@ export class LegendImageComponent {
       url: legend.url,
       srcset: '',
       scaleHiDpiImage: legend.url.includes('/uploads/legend/') && !legend.url.endsWith('.svg'),
-      failedToLoadMessage: `${FAILED_TO_LOAD_MESSAGE} ${legend.title}`,
+      altText: `${LOCALISED_ALT_TEXT} ${legend.title}`,
     };
     if (legend.legendType == 'dynamic') {
       if (legend.serverType === 'geoserver') {


### PR DESCRIPTION
[![HTM-2169](https://badgen.net/badge/JIRA/HTM-2169/7A54FF?icon=jira)](https://b3partners.atlassian.net/browse/HTM-2169) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=Tailormap&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

 

[HTM-2169]: https://b3partners.atlassian.net/browse/HTM-2169?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ