### PR TITLE
HTM-2170: WCAG 4.1.2: Remove the (untranslated) 'toggle' text from TOC checkbox/radiobuttons

### DIFF
--- a/projects/core/src/lib/components/toc/toc/toc.component.spec.ts
+++ b/projects/core/src/lib/components/toc/toc/toc.component.spec.ts
@@ -115,8 +115,8 @@ describe('TocComponent', () => {
   test('handles checking layer', async () => {
     const { mockDispatch } = await setup(true, '1');
     expect(await screen.findByText('Disaster map')).toBeInTheDocument();
-    expect(await screen.getByLabelText('toggle Disaster map')).toBeInTheDocument();
-    await userEvent.click(await screen.getByLabelText('toggle Disaster map'));
+    expect(await screen.getByLabelText('Disaster map')).toBeInTheDocument();
+    await userEvent.click(await screen.getByLabelText('Disaster map'));
     expect(mockDispatch).toHaveBeenCalledWith({ type: setLayerVisibility.type, visibility: [{ id: '1', checked: true }] });
   });
 

--- a/projects/shared/src/lib/components/tree/tree.component.html
+++ b/projects/shared/src/lib/components/tree/tree.component.html
@@ -34,7 +34,7 @@
            (dragstart)="treeDragDropServiceEnabled ? handleDragStart($event, node) : null">
         @if (!hasChild(node)) {
           @if (node.checkbox && !useRadioInputs) {
-            <mat-checkbox [aria-label]="'toggle ' + node.label"
+            <mat-checkbox [aria-label]="node.label"
                           [checked]="isChecked(node)"
                           [disabled]="readOnlyMode"
                           (click)="$event.stopPropagation()"
@@ -43,7 +43,7 @@
           } @else if (useRadioInputs) {
             <mat-radio-button [disabled]="readOnlyMode"
                               [checked]="isChecked(node)"
-                              [aria-label]="'toggle ' + node.label"
+                              [aria-label]="node.label"
                               (click)="handleRadioChange(node, $event)"
                               [value]="node"
                               class="tree-radio-button"></mat-radio-button>
@@ -59,7 +59,7 @@
           }
           @if (node.checkbox && !useRadioInputs) {
             <mat-checkbox [disabled]="readOnlyMode"
-                          [aria-label]="'toggle ' + node.label"
+                          [aria-label]="node.label"
                           (click)="$event.stopPropagation()"
                           (change)="toggleGroupChecked(node)"
                           [checked]="isChecked(node)"


### PR DESCRIPTION
[![HTM-2170](https://badgen.net/badge/JIRA/HTM-2170/7A54FF?icon=jira)](https://b3partners.atlassian.net/browse/HTM-2170) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=Tailormap&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

This is redundant information; the label should describe the purpose, not the action (the latter is implicit from the control) 

[HTM-2170]: https://b3partners.atlassian.net/browse/HTM-2170?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ