### PR TITLE
HTM-2171: WCAG 1.1.1: Add descriptive text to logo on login form

### DIFF
--- a/projects/core/src/lib/pages/login/login-form/login-form.component.html
+++ b/projects/core/src/lib/pages/login/login-form/login-form.component.html
@@ -5,7 +5,7 @@
     <div class="login-form__header">
       <div class="login-title" i18n="@@shared.login-form.title">Login</div>
       <div class="logo-container">
-        <mat-icon class="logo" svgIcon="logo"></mat-icon>
+        <mat-icon aria-hidden="false" aria-label="Tailormap" class="logo" svgIcon="logo"></mat-icon>
         <div class="logo-background"></div>
       </div>
     </div>


### PR DESCRIPTION
[![HTM-2171](https://badgen.net/badge/JIRA/HTM-2171/7A54FF?icon=jira)](https://b3partners.atlassian.net/browse/HTM-2171) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=Tailormap&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

make the logo informative instead of decorative and add a label 

[HTM-2171]: https://b3partners.atlassian.net/browse/HTM-2171?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ