### PR TITLE
HTM-2166: WCAG 1.3.1 Properly markup headers in "About" dialog

### DIFF
--- a/projects/shared/src/lib/components/about-dialog/about-dialog.component.css
+++ b/projects/shared/src/lib/components/about-dialog/about-dialog.component.css
@@ -15,4 +15,5 @@
 .label {
   font-weight: bold;
   padding-bottom: 3px;
+  font-size: 16px;
 }

--- a/projects/shared/src/lib/components/about-dialog/about-dialog.component.html
+++ b/projects/shared/src/lib/components/about-dialog/about-dialog.component.html
@@ -15,11 +15,11 @@
   }
   @if (version$ | async; as version) {
     <div class="row">
-      <div class="label" i18n="@@shared.about.version">Version</div>
+      <h2 class="label" i18n="@@shared.about.version">Version</h2>
       <div><ng-container *ngTemplateOutlet="infoOrUnknown; context: {$implicit: version.version}"></ng-container></div>
     </div>
     <div class="row">
-      <div class="label" i18n="@@shared.about.build-date">Build date</div>
+      <h2 class="label" i18n="@@shared.about.build-date">Build date</h2>
       <div>
         @if (version.buildDate) {
           <span>{{version.buildDate | date:"mediumDate" }}</span>&nbsp;
@@ -32,7 +32,7 @@
     </div>
     @if (version.addedPackages.length > 0) {
       <div class="row">
-        <div class="label" i18n="@@shared.about.added-packages">Extensions</div>
+        <h2 class="label" i18n="@@shared.about.added-packages">Extensions</h2>
         <div>
           @for (pkg of version.addedPackages; track pkg) {
             <div>
@@ -45,6 +45,6 @@
   }
 </div>
 
-<div mat-dialog-actions align="end">
-  <button mat-button color="primary" (click)="close()" i18n="@@shared.common.close">Close</button>
+<div align="end" mat-dialog-actions>
+  <button (click)="close()" color="primary" i18n="@@shared.common.close" mat-flat-button>Close</button>
 </div>


### PR DESCRIPTION
[![HTM-2166](https://badgen.net/badge/JIRA/HTM-2166/7A54FF?icon=jira)](https://b3partners.atlassian.net/browse/HTM-2166) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=Tailormap&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

Also use a `mat-flat-button` in primary colour which has a higher contrast

<img width="566" height="565" alt="image" src="https://github.com/user-attachments/assets/018106d7-3510-48b9-b39c-c7af34254733" /> 

[HTM-2166]: https://b3partners.atlassian.net/browse/HTM-2166?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ